### PR TITLE
[FAB2023-604] checkboxlist 컴포넌트 상속 구조로 변경

### DIFF
--- a/project/ui/frontend/common/components/extends/check-box-list/CheckBoxList.vue
+++ b/project/ui/frontend/common/components/extends/check-box-list/CheckBoxList.vue
@@ -33,7 +33,7 @@ function onChange(value: (string | number)[]) {
   emit("change", value);
 }
 
-const { data, labelKey, valueKey, checkboxList, changeList, isDisabled } = CheckBoxListComposition(props, onChange);
+const { data, labelKey, checkboxList, changeList } = CheckBoxListComposition(props, onChange);
 </script>
 
 <style lang="scss" scoped>

--- a/project/ui/frontend/common/components/extends/check-box-list/CheckBoxList.vue
+++ b/project/ui/frontend/common/components/extends/check-box-list/CheckBoxList.vue
@@ -1,0 +1,41 @@
+<template>
+  <client-only>
+    <div v-for="(option, index) in checkboxList" :key="index">
+      <input
+        type="checkbox"
+        :id="option.id"
+        :value="option.value"
+        @change="changeList"
+        :disabled="option.disabled"
+        v-model="option.checked"
+      />
+      <label :for="option.id"> {{ option[labelKey] }} </label>
+    </div>
+  </client-only>
+</template>
+
+<script setup lang="ts">
+import { CheckBoxListProps } from "@/components/extends/check-box-list/CheckBoxListProps";
+import { CheckBoxListComposition } from "@/components/extends/check-box-list/CheckBoxListComposition";
+
+const props = withDefaults(defineProps<CheckBoxListProps>(), {
+  data: () => [],
+  labelKey: "label",
+  valueKey: "value",
+  checkedList: () => [],
+  disabledList: () => [],
+  isFirstSelectedEvent: false,
+  checkboxList: () => []
+});
+
+const emit = defineEmits<{ (e: "change", item: (string | number)[]): void }>();
+function onChange(value: (string | number)[]) {
+  emit("change", value);
+}
+
+const { data, labelKey, valueKey, checkboxList, changeList, isDisabled } = CheckBoxListComposition(props, onChange);
+</script>
+
+<style lang="scss" scoped>
+/* @import "./index.scss"; */
+</style>

--- a/project/ui/frontend/common/components/extends/check-box-list/CheckBoxListComposition.ts
+++ b/project/ui/frontend/common/components/extends/check-box-list/CheckBoxListComposition.ts
@@ -1,0 +1,66 @@
+import { CheckBoxListProps } from "@/components/extends/check-box-list/CheckBoxListProps";
+import { ComputedRef } from "vue";
+import { uuid } from "vue3-uuid";
+import { CheckFunctionality } from "~/components/extends/common/interfaces/functions/Check.interface";
+import { CheckEvents } from "~/components/extends/common/interfaces/events/Check.interface";
+
+export interface CheckBoxListComposition extends CheckBoxListProps, CheckFunctionality, CheckEvents {
+  checkboxList: ComputedRef<any>;
+  changeList(option: any): void;
+}
+
+export function CheckBoxListComposition(
+  props: CheckBoxListProps,
+  onchange: (value: any) => void
+): CheckBoxListComposition {
+  const checkboxList: ComputedRef<any> = computed(() => {
+    const labelKey: string = props.labelKey;
+    const valueKey: string | number = props.valueKey;
+    const checkedList: (string | number)[] | undefined = props.checkedList;
+    const disabledList: (string | number)[] | undefined = props.disabledList;
+
+    return props.data.map((value) => {
+      return {
+        id: value.id ?? uuid.v4(),
+        label: value[labelKey],
+        value: value[valueKey],
+        checked: checkedList?.includes(value[valueKey]),
+        disabled: disabledList?.includes(value[valueKey])
+      };
+    });
+  });
+  const onChange: (value: any) => void = (value) => {
+    onchange(value);
+  };
+  const changeList: (option: any) => void = () => {
+    const checkedValues = checkboxList.value
+      .filter((item: { checked: any }) => item.checked)
+      .map((item: { value: any }) => item.value);
+    onChange(checkedValues);
+  };
+
+  if (props.isFirstSelectedEvent) {
+    const selectedOptions = props.data.filter(
+      (item) => props.checkedList?.includes(item[props.valueKey]) && !props.disabledList?.includes(item[props.valueKey])
+    );
+    if (selectedOptions.length > 0) {
+      const selectedValues = selectedOptions.map((item) => item[props.valueKey]);
+      onChange(selectedValues);
+    } else {
+      console.warn("선택된 값이 목록에 없거나 disabledList 목록에 선택한 값이 존재합니다.");
+    }
+  }
+
+  const isDisabled: (value: string | number) => boolean = (value) => {
+    // @ts-ignore
+    return props.disabledList.includes(value);
+  };
+
+  return {
+    ...props,
+    checkboxList,
+    changeList,
+    onChange,
+    isDisabled
+  };
+}

--- a/project/ui/frontend/common/components/extends/check-box-list/CheckBoxListProps.ts
+++ b/project/ui/frontend/common/components/extends/check-box-list/CheckBoxListProps.ts
@@ -1,0 +1,5 @@
+import { SelectProps } from "@/components/extends/common/interfaces/props/Select.interface";
+
+export interface CheckBoxListProps extends SelectProps {
+  checkedList?: (string | number)[];
+}

--- a/project/ui/frontend/common/components/extends/common/interfaces/events/Check.interface.ts
+++ b/project/ui/frontend/common/components/extends/common/interfaces/events/Check.interface.ts
@@ -1,0 +1,3 @@
+export interface CheckEvents {
+  onChange(value: any): void;
+}

--- a/project/ui/frontend/common/components/extends/common/interfaces/functions/Check.interface.ts
+++ b/project/ui/frontend/common/components/extends/common/interfaces/functions/Check.interface.ts
@@ -1,0 +1,3 @@
+export interface CheckFunctionality {
+  isDisabled(value: string | number): boolean;
+}

--- a/project/ui/frontend/common/nuxt.config.ts
+++ b/project/ui/frontend/common/nuxt.config.ts
@@ -4,7 +4,7 @@ export default defineNuxtConfig({
 
   modules: ["@nuxtjs/svg-sprite", "nuxt-lodash", "dayjs-nuxt", "@nuxtjs/tailwindcss"],
 
-  plugins: [
+  "plugins": [
     { src: "~/plugins/highcharts-vue", mode: "client" },
     { src: "~/plugins/vue-final-modal", mode: "client" },
     { src: "~/plugins/ag-grid-vue", mode: "client" },

--- a/project/ui/frontend/common/package.json
+++ b/project/ui/frontend/common/package.json
@@ -46,7 +46,8 @@
     "nuxt-lodash": "^2.5.3",
     "prettier": "^3.2.4",
     "vue-datepicker-next": "^1.0.3",
-    "vue-final-modal": "^4.5.3"
+    "vue-final-modal": "^4.5.3",
+    "vue3-uuid": "^1.0.0"
   },
   "browserslist": [
     ">0.3%",

--- a/project/ui/frontend/common/pages/checkboxList/index.vue
+++ b/project/ui/frontend/common/pages/checkboxList/index.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <CheckBoxList
+      :data="options"
+      label-key="label"
+      value-key="value"
+      :checkedList="checkedList"
+      :disabledList="disabledList"
+      :isFirstSelectedEvent="isFirstSelectedEvent"
+      @change="checkItem"
+    ></CheckBoxList>
+  </div>
+</template>
+
+<script setup lang="ts">
+import CheckBoxList from "@/components/extends/check-box-list/CheckBoxList.vue";
+const isFirstSelectedEvent: Boolean = true;
+
+let checkedList = ["option22", "option44"];
+
+const disabledList = ["option44"];
+
+const options = [
+  {
+    label: "option1",
+    value: "option11"
+  },
+  {
+    label: "option2",
+    value: "option22"
+  },
+  {
+    label: "option3",
+    value: "option33"
+  },
+  {
+    label: "option4",
+    value: "option44"
+  }
+];
+const checkItem = (val: (string | number)[]) => {
+  console.log(val);
+};
+
+onBeforeMount(() => {
+  checkedList = checkedList?.filter((item) => !disabledList.includes(item));
+});
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## 유형
- Feature (기능 추가 or 개선)

## 이슈 링크
- [FAB2023-604](https://mobigen.atlassian.net/browse/FAB2023-604)

## 수정 내용
- [FAB2023-652](https://mobigen.atlassian.net/browse/FAB2023-652)
- CheckBoxList 컴포넌트 상속 구조로 변경

[FAB2023-604]: https://mobigen.atlassian.net/browse/FAB2023-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FAB2023-652]: https://mobigen.atlassian.net/browse/FAB2023-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ