### PR TITLE
[FAB2023-604] checkboxlist2차 컴포넌트 상속 구조로 변경[수정]

### DIFF
--- a/project/ui/frontend/common/components/extends/check-box-list/CheckBoxList.vue
+++ b/project/ui/frontend/common/components/extends/check-box-list/CheckBoxList.vue
@@ -9,7 +9,7 @@
         :disabled="option.disabled"
         v-model="option.checked"
       />
-      <label :for="option.id"> {{ option[labelKey] }} </label>
+      <label :for="option.id"> {{ option.label }} </label>
     </div>
   </client-only>
 </template>
@@ -33,7 +33,7 @@ function onChange(value: (string | number)[]) {
   emit("change", value);
 }
 
-const { data, labelKey, checkboxList, changeList } = CheckBoxListComposition(props, onChange);
+const { checkboxList, changeList } = CheckBoxListComposition(props, onChange);
 </script>
 
 <style lang="scss" scoped>

--- a/project/ui/frontend/common/components/extends/check-box-list/CheckBoxListComposition.ts
+++ b/project/ui/frontend/common/components/extends/check-box-list/CheckBoxListComposition.ts
@@ -6,12 +6,12 @@ import { CheckEvents } from "~/components/extends/common/interfaces/events/Check
 
 export interface CheckBoxListComposition extends CheckBoxListProps, CheckFunctionality, CheckEvents {
   checkboxList: ComputedRef<any>;
-  changeList(option: any): void;
+  changeList(option: string | number): void;
 }
 
 export function CheckBoxListComposition(
   props: CheckBoxListProps,
-  onchange: (value: any) => void
+  onchangeList: (option: (string | number)[]) => void
 ): CheckBoxListComposition {
   const checkboxList: ComputedRef<any> = computed(() => {
     const labelKey: string = props.labelKey;
@@ -29,14 +29,17 @@ export function CheckBoxListComposition(
       };
     });
   });
-  const onChange: (value: any) => void = (value) => {
-    onchange(value);
+  // @ts-ignore
+  // NOTE: onChange 이벤트는 지금은 사용 안함.
+  const onChange: (value: string | number) => void = (value: string | number) => {};
+  const onChangeList: (value: (string | number)[]) => void = (value) => {
+    onchangeList(value);
   };
-  const changeList: (option: any) => void = () => {
+  const changeList: () => void = () => {
     const checkedValues = checkboxList.value
-      .filter((item: { checked: any }) => item.checked)
-      .map((item: { value: any }) => item.value);
-    onChange(checkedValues);
+      .filter((item: { checked: boolean }) => item.checked)
+      .map((item: { value: string | number }) => item.value);
+    onChangeList(checkedValues);
   };
 
   if (props.isFirstSelectedEvent) {
@@ -45,7 +48,7 @@ export function CheckBoxListComposition(
     );
     if (selectedOptions.length > 0) {
       const selectedValues = selectedOptions.map((item) => item[props.valueKey]);
-      onChange(selectedValues);
+      onChangeList(selectedValues);
     } else {
       console.warn("선택된 값이 목록에 없거나 disabledList 목록에 선택한 값이 존재합니다.");
     }
@@ -61,6 +64,7 @@ export function CheckBoxListComposition(
     checkboxList,
     changeList,
     onChange,
+    onChangeList,
     isDisabled
   };
 }

--- a/project/ui/frontend/common/components/extends/common/interfaces/events/Check.interface.ts
+++ b/project/ui/frontend/common/components/extends/common/interfaces/events/Check.interface.ts
@@ -1,3 +1,4 @@
 export interface CheckEvents {
-  onChange(value: any): void;
+  onChange(value: string | number): void;
+  onChangeList(value: (string | number)[]): void;
 }


### PR DESCRIPTION
## 유형
- Task (기능 변경 외 작업)

## 이슈 링크
- [FAB2023-604](https://mobigen.atlassian.net/browse/FAB2023-604)

## 수정 내용
- [FAB2023-652](https://mobigen.atlassian.net/browse/FAB2023-652)
-  onChangeList로 이벤트 추가
- 타입 수정
- 불필요한 코드 삭제

[FAB2023-604]: https://mobigen.atlassian.net/browse/FAB2023-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FAB2023-652]: https://mobigen.atlassian.net/browse/FAB2023-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ