### PR TITLE
[FAB2023-898] 탐색 목록 - 모델 명 클릭시 상세 페이지 이동 및 header 검색어 처리 구현

### DIFF
--- a/project/ovp/frontend/common/components/extends/search-input/SearchInput.vue
+++ b/project/ovp/frontend/common/components/extends/search-input/SearchInput.vue
@@ -45,7 +45,6 @@ const emit = defineEmits<{
   (e: "onClickSearch", value: string): void;
   (e: "onChange", value: string): void;
   (e: "onInput", value: string): void;
-  (e: "onSearch", value: string): void;
 }>();
 
 const onClickSearch = () => {

--- a/project/ovp/frontend/common/components/extends/search-input/SearchInput.vue
+++ b/project/ovp/frontend/common/components/extends/search-input/SearchInput.vue
@@ -6,9 +6,9 @@
       id="searchInp"
       class="text-input"
       v-model="inputValue"
-      @keyup.enter="setSearchValue(inputValue)"
-      @change="setSearchValue(inputValue)"
-      @input="setSearchValue(inputValue)"
+      @keyup.enter="onClickSearch"
+      @change="onChange"
+      @input="onInput"
       :placeholder="placeholder"
       :disabled="disabled"
       :isSearchInputDefaultType="isSearchInputDefaultType"
@@ -23,7 +23,7 @@
     </button>
     <button
       class="search-input-button button button-neutral-ghost"
-      @click="onClickSearch(inputValue)"
+      @click="onClickSearch"
       v-if="isSearchInputDefaultType"
     >
       <span class="hidden-text">검색</span>
@@ -42,16 +42,20 @@ const props = withDefaults(defineProps<SearchInputProps>(), {
 });
 
 const emit = defineEmits<{
-  (e: "search", value: string): void;
   (e: "onClickSearch", value: string): void;
+  (e: "onChange", value: string): void;
+  (e: "onInput", value: string): void;
+  (e: "onSearch", value: string): void;
 }>();
 
-const setSearchValue = (value: string) => {
-  emit("search", value);
+const onClickSearch = () => {
+  emit("onClickSearch", inputValue.value);
 };
-
-const onClickSearch = (value: string) => {
-  emit("onClickSearch", value);
+const onChange = () => {
+  emit("onChange", inputValue.value);
+};
+const onInput = () => {
+  emit("onInput", inputValue.value);
 };
 
 const { inputValue, clearSearchValue } = SearchInputComposition(props);

--- a/project/ovp/frontend/common/components/extends/search-input/SearchInput.vue
+++ b/project/ovp/frontend/common/components/extends/search-input/SearchInput.vue
@@ -23,7 +23,7 @@
     </button>
     <button
       class="search-input-button button button-neutral-ghost"
-      @click="setSearchValue(inputValue)"
+      @click="setBtnClick(inputValue)"
       v-if="isSearchInputDefaultType"
     >
       <span class="hidden-text">검색</span>
@@ -41,10 +41,17 @@ const props = withDefaults(defineProps<SearchInputProps>(), {
   disabled: false
 });
 
-const emit = defineEmits<{ (e: "search", value: string): void }>();
+const emit = defineEmits<{
+  (e: "search", value: string): void;
+  (e: "searchBtnClick", value: string): void;
+}>();
 
 const setSearchValue = (value: string) => {
-  value !== "" ? emit("search", value) : window.location.reload();
+  emit("search", value);
+};
+
+const setBtnClick = (value: string) => {
+  emit("searchBtnClick", value);
 };
 
 const { inputValue, clearSearchValue } = SearchInputComposition(props);

--- a/project/ovp/frontend/common/components/extends/search-input/SearchInput.vue
+++ b/project/ovp/frontend/common/components/extends/search-input/SearchInput.vue
@@ -23,7 +23,7 @@
     </button>
     <button
       class="search-input-button button button-neutral-ghost"
-      @click="setBtnClick(inputValue)"
+      @click="onClickSearch(inputValue)"
       v-if="isSearchInputDefaultType"
     >
       <span class="hidden-text">검색</span>
@@ -43,15 +43,15 @@ const props = withDefaults(defineProps<SearchInputProps>(), {
 
 const emit = defineEmits<{
   (e: "search", value: string): void;
-  (e: "searchBtnClick", value: string): void;
+  (e: "onClickSearch", value: string): void;
 }>();
 
 const setSearchValue = (value: string) => {
   emit("search", value);
 };
 
-const setBtnClick = (value: string) => {
-  emit("searchBtnClick", value);
+const onClickSearch = (value: string) => {
+  emit("onClickSearch", value);
 };
 
 const { inputValue, clearSearchValue } = SearchInputComposition(props);

--- a/project/ovp/frontend/ovp/components/common/resource-box/resource-box-common-props.ts
+++ b/project/ovp/frontend/ovp/components/common/resource-box/resource-box-common-props.ts
@@ -7,6 +7,7 @@ export interface DataModel {
   modelDesc: string;
   owner: string;
   category: string;
+  [key: string]: string | number | string[];
 }
 
 export interface ResourceBoxCommonProps {

--- a/project/ovp/frontend/ovp/components/common/resource-box/resource-box-list.vue
+++ b/project/ovp/frontend/ovp/components/common/resource-box/resource-box-list.vue
@@ -51,15 +51,15 @@ const props = withDefaults(defineProps<ResourceBoxListProps>(), {
 
 const emit = defineEmits<{
   (e: "previewClick", id: string | number): void;
-  (e: "modelNmClick", id: string | number): void;
+  (e: "modelNmClick", data: object): void;
   (e: "checkedValueChanged", ids: any[]): void;
 }>();
 const previewClick = (id: string | number) => {
   selectedResourceBoxId.value = id;
   emit("previewClick", id);
 };
-const modelNmClick = (id: string | number) => {
-  emit("modelNmClick", id);
+const modelNmClick = (data: object) => {
+  emit("modelNmClick", data);
 };
 
 const checked = ($evt: Event, id: string | number) => {

--- a/project/ovp/frontend/ovp/components/common/resource-box/resource-box.vue
+++ b/project/ovp/frontend/ovp/components/common/resource-box/resource-box.vue
@@ -23,7 +23,9 @@
         </div>
       </div>
     </div>
-    <div class="resource-box-initial-name" v-if="useFirModelNm">{{ props.dataObj.firModelNm }}</div>
+    <div class="resource-box-initial-name" v-if="useFirModelNm">
+      {{ props.dataObj.firModelNm }}
+    </div>
 
     <resource-box-edit-part
       partKey="modelNm"
@@ -51,7 +53,7 @@
             class="editable-group-title"
             title="상세 보기"
             @click.stop="modelNmClick"
-          >{{ props.dataObj.modelNm }}</a
+            >{{ props.dataObj.modelNm }}</a
           >
         </template>
         <template v-else>
@@ -147,12 +149,12 @@ const newValue = ref<Record<string, any>>({});
 
 const props = withDefaults(defineProps<ResourceBoxProps>(), {
   useDataNmLink: false,
-  editable: false
+  editable: false,
 });
 
 const emit = defineEmits<{
   (e: "previewClick", id: string | number): void;
-  (e: "modelNmClick", id: string | number): void;
+  (e: "modelNmClick", data: object): void;
 }>();
 
 const previewClick = () => {
@@ -161,7 +163,7 @@ const previewClick = () => {
   }
 };
 const modelNmClick = () => {
-  emit("modelNmClick", props.dataObj.id);
+  emit("modelNmClick", props.dataObj);
 };
 
 const editIconClick = (key: string) => {

--- a/project/ovp/frontend/ovp/components/search/data-filter.vue
+++ b/project/ovp/frontend/ovp/components/search/data-filter.vue
@@ -28,7 +28,7 @@ import { storeToRefs } from "pinia";
 import _ from "lodash";
 
 const searchCommonStore = useSearchCommonStore();
-const { setQueryFilter } = searchCommonStore;
+const { resetReloadList } = searchCommonStore;
 const { selectedFilters } = storeToRefs(searchCommonStore);
 
 const props = defineProps({
@@ -44,7 +44,7 @@ const resetFilters = () => {
   selectedFilterItems.value = [];
   selectedFilters.value = {};
 
-  setQueryFilter();
+  resetReloadList();
 };
 
 const changeMultiple: (value: any[] | {}, keyName: any) => void = (
@@ -59,7 +59,7 @@ const changeMultiple: (value: any[] | {}, keyName: any) => void = (
     selectedFilters.value[keyName] = selectedIds;
   }
 
-  setQueryFilter();
+  resetReloadList();
 };
 </script>
 

--- a/project/ovp/frontend/ovp/layouts/header.vue
+++ b/project/ovp/frontend/ovp/layouts/header.vue
@@ -7,7 +7,7 @@
           <span class="hidden-text">logo</span>
         </a>
       </h1>
-      <SearchInput @searchBtnClick="searchBtnClick"></SearchInput>
+      <SearchInput @onClickSearch="onClickSearch"></SearchInput>
       <div class="profile ml-auto">
         <span class="profile-avatar">
           <img class="profile-img" src="" alt="프로필 이미지" />
@@ -58,7 +58,7 @@ import { useSearchCommonStore } from "~/store/search/common";
 const searchCommonStore = useSearchCommonStore();
 const { setSearchKeyword } = searchCommonStore;
 
-const searchBtnClick = (value: string) => {
+const onClickSearch = (value: string) => {
   setSearchKeyword(value);
 };
 </script>

--- a/project/ovp/frontend/ovp/layouts/header.vue
+++ b/project/ovp/frontend/ovp/layouts/header.vue
@@ -56,10 +56,14 @@ import SearchInput from "@extends/search-input/SearchInput.vue";
 
 import { useSearchCommonStore } from "~/store/search/common";
 const searchCommonStore = useSearchCommonStore();
-const { setSearchKeyword } = searchCommonStore;
+const { setSearchKeyword, resetReloadList } = searchCommonStore;
 
 const onClickSearch = (value: string) => {
+  // 검색어 셋팅
   setSearchKeyword(value);
+
+  // 항목 갱신
+  resetReloadList();
 };
 </script>
 

--- a/project/ovp/frontend/ovp/layouts/header.vue
+++ b/project/ovp/frontend/ovp/layouts/header.vue
@@ -7,7 +7,7 @@
           <span class="hidden-text">logo</span>
         </a>
       </h1>
-      <SearchInput></SearchInput>
+      <SearchInput @searchBtnClick="searchBtnClick"></SearchInput>
       <div class="profile ml-auto">
         <span class="profile-avatar">
           <img class="profile-img" src="" alt="프로필 이미지" />
@@ -53,6 +53,14 @@
 
 <script setup lang="ts">
 import SearchInput from "@extends/search-input/SearchInput.vue";
+
+import { useSearchCommonStore } from "~/store/search/common";
+const searchCommonStore = useSearchCommonStore();
+const { setSearchKeyword } = searchCommonStore;
+
+const searchBtnClick = (value: string) => {
+  setSearchKeyword(value);
+};
 </script>
 
 <style scoped></style>

--- a/project/ovp/frontend/ovp/pages/portal/search/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/search/index.vue
@@ -58,6 +58,8 @@ import { useSearchCommonStore } from "@/store/search/common";
 import { IntersectionObserverHandler } from "@/utils/intersection-observer";
 
 import TopBar from "./top-bar.vue";
+import { useRouter } from "nuxt/app";
+const router = useRouter();
 
 const searchCommonStore = useSearchCommonStore();
 const { getSearchList, getFilters, getPreviewData, setScrollFrom } =
@@ -92,8 +94,14 @@ const previewClick = async (id: string | number) => {
   currentPreviewId = id;
 };
 
-const modelNmClick = (id: string | number) => {
-  console.log(`modelNmClick : ${id}`);
+const modelNmClick = (data: { id: string; fqn: string }) => {
+  router.push({
+    path: "/portal/search/detail",
+    query: {
+      id: data.id,
+      fqn: data.fqn,
+    },
+  });
 };
 
 // TODO: intersection observer 옵션이 부족해 보임. 데이터가 1000가 넘으면 UI가 버벅거림.

--- a/project/ovp/frontend/ovp/pages/portal/search/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/search/index.vue
@@ -63,11 +63,12 @@ const router = useRouter();
 
 const searchCommonStore = useSearchCommonStore();
 const {
-  getSearchList,
+  addSearchList,
   getFilters,
   getPreviewData,
   setScrollFrom,
   setIntersectionHandler,
+  updateIntersectionHandler,
 } = searchCommonStore;
 const {
   from,
@@ -99,12 +100,13 @@ const previewClick = async (id: string | number) => {
   currentPreviewId = id;
 };
 
-const modelNmClick = (data: { id: string; fqn: string }) => {
+const modelNmClick = (data: object) => {
+  const { id, fqn } = data as { id: string; fqn: string };
   router.push({
     path: "/portal/search/detail",
     query: {
-      id: data.id,
-      fqn: data.fqn,
+      id: id,
+      fqn: fqn,
     },
   });
 };
@@ -121,16 +123,16 @@ const loaderId = "loader";
 let intersectionHandler: IntersectionObserverHandler | null = null;
 // 스크롤 이동시 데이터 로딩 시점에 실행되는 callback
 const getDataCallback = async (count: number, loader: HTMLElement | null) => {
-  console.log(`callback ${count}`);
   // loader start
   if (loader) {
     loader.style.display = "flex";
   }
 
-  // 데이터 조회
-  // 조회 쿼리는 store 에서 처리.
   setScrollFrom(count);
-  await getSearchList();
+  updateIntersectionHandler(count);
+
+  // 데이터 조회 : 쿼리는 store 에서 처리.
+  await addSearchList();
 
   if (loader) {
     loader.style.display = "none";
@@ -138,7 +140,11 @@ const getDataCallback = async (count: number, loader: HTMLElement | null) => {
 };
 
 onMounted(async () => {
-  await getSearchList(false);
+  // top-bar 에서 select box (sort) 값이 변경되면 목록을 조회하라는 코드가 구현되어 있는데,
+  // select box 가 화면 맨 처음에 뿌릴때 값을 초기에 1번 셋팅하는 부분에서 목록 조회가 이뤄짐.
+  // 중복 호출을 피하기 위해서 여기서는 목록 데이터를 조회하지 않음.
+  // await getSearchList();
+
   await getFilters();
 
   // intersection observer instance 생성

--- a/project/ovp/frontend/ovp/pages/portal/search/top-bar.vue
+++ b/project/ovp/frontend/ovp/pages/portal/search/top-bar.vue
@@ -54,7 +54,7 @@ import CONSTANTS from "~/constants/constants";
 import _ from "lodash";
 
 const searchCommonStore = useSearchCommonStore();
-const { setSortInfo } = searchCommonStore;
+const { setSortInfo, resetReloadList } = searchCommonStore;
 const { viewType, searchResultLength, sortKey, sortKeyOpt } =
   storeToRefs(searchCommonStore);
 
@@ -65,6 +65,9 @@ const isFirstCheckedEvent: boolean = true;
 const selectItem = (item: string | number) => {
   if (!_.isUndefined(item) && typeof item === "string") {
     setSortInfo(item);
+
+    // 항목 갱신
+    resetReloadList();
   }
 };
 </script>

--- a/project/ovp/frontend/ovp/store/search/common.ts
+++ b/project/ovp/frontend/ovp/store/search/common.ts
@@ -139,9 +139,8 @@ export const useSearchCommonStore = defineStore("searchCommon", () => {
 
   // List Query data
   let searchKeyword: string = "";
-  const SIZE_CNT = 10;
   const from: Ref<number> = ref<number>(0);
-  const size: Ref<number> = ref<number>(SIZE_CNT);
+  const size: Ref<number> = ref<number>(100);
   const sortKey: Ref<string> = ref<string>("totalVotes");
   const sortKeyOpt: Ref<string> = ref<string>("desc");
 

--- a/project/ovp/frontend/ovp/store/search/common.ts
+++ b/project/ovp/frontend/ovp/store/search/common.ts
@@ -56,11 +56,6 @@ export interface details {
     rows: any[];
   };
   profiling: any[];
-
-  // TODO : 처리방법 고려 (별도로 조회할껀지 확인 필요)
-  // query: [];
-  // lineage: {};
-  // recommendModel: [];
 }
 
 export interface SelectedFilters {
@@ -91,8 +86,6 @@ export interface QueryFilter {
 
 import previewJson from "./samples/preview.json";
 import detailsJson from "./samples/details.json";
-
-import _ from "lodash";
 
 export const useSearchCommonStore = defineStore("searchCommon", () => {
   const { $api } = useNuxtApp();
@@ -137,9 +130,6 @@ export const useSearchCommonStore = defineStore("searchCommon", () => {
     },
   });
   const selectedFilters: Ref<SelectedFilters> = ref({} as SelectedFilters);
-  const queryFilter: Ref<QueryFilter> = ref({
-    query: { bool: { must: [] } },
-  });
 
   // DATA
   const viewType: Ref<string> = ref<string>("listView");
@@ -148,8 +138,8 @@ export const useSearchCommonStore = defineStore("searchCommon", () => {
   const searchResultLength: Ref<number> = ref<number>(0);
 
   // List Query data
-  const searchKeyword: Ref<string> = ref<string>("");
-  const SIZE_CNT = 100;
+  let searchKeyword: string = "";
+  const SIZE_CNT = 10;
   const from: Ref<number> = ref<number>(0);
   const size: Ref<number> = ref<number>(SIZE_CNT);
   const sortKey: Ref<string> = ref<string>("totalVotes");
@@ -160,42 +150,46 @@ export const useSearchCommonStore = defineStore("searchCommon", () => {
       // open-meta 에서 사용 하는 key 이기 때문에 그대로 사용.
       // eslint 예외 제외 코드 추가.
       // eslint-disable-next-line id-length
-      q: "employee",
+      q: searchKeyword,
       index: "table_search_index,container_search_index",
       from: from.value,
       size: size.value,
       deleted: false,
-      query_filter: JSON.stringify(queryFilter.value),
+      query_filter: JSON.stringify(getQueryFilter()),
       sort_field: sortKey.value,
       sort_order: sortKeyOpt.value,
     };
     return new URLSearchParams(params);
   };
   // METHODS
-  const getSearchList = async (useAdd: boolean = true) => {
-    const { totalCount, data } = await $api(
-      `/api/search/list?${getSearchListQuery()}`,
-    );
+  const getSearchListAPI = async () => {
+    const { data } = await $api(`/api/search/list?${getSearchListQuery()}`);
+    return data;
+  };
+  /**
+   * 데이터 조회 -> 누적
+   */
+  const addSearchList = async () => {
+    const { data, totalCount } = await getSearchListAPI();
+    searchResult.value = searchResult.value.concat(data);
+    searchResultLength.value = totalCount;
+  };
 
-    // 조회한 데이터 누적 or 대치
-    searchResult.value = useAdd ? searchResult.value.concat(data) : data;
+  /**
+   * 데이터 조회 -> 갱신
+   */
+  const getSearchList = async () => {
+    const { data, totalCount } = await getSearchListAPI();
+    searchResult.value = data;
     searchResultLength.value = totalCount;
   };
   const getFilters = async () => {
-    const data = await $api(`/api/search/filters`);
+    const { data } = await $api(`/api/search/filters`);
 
-    // 사용할 필터를 정리
-    const useFilters: string[] = [
-      "domains",
-      "owner.displayName.keyword",
-      "tags.tagFQN",
-      "service.displayName.keyword",
-      "serviceType",
-      "database.displayName.keyword",
-      "databaseSchema.displayName.keyword",
-      "columns.name.keyword",
-      "tableType",
-    ];
+    // 기본값 기준 사용할 필터 key 를 정리
+    const defaultFilters = createDefaultFilters();
+    const useFilters = Object.keys(defaultFilters);
+
     useFilters.forEach((key: string) => {
       (filters.value as any)[key].data = data[key];
     });
@@ -228,78 +222,47 @@ export const useSearchCommonStore = defineStore("searchCommon", () => {
     return setBoolObj.value;
   };
 
-  const setQueryFilter = () => {
-    queryFilter.value = {
+  const getQueryFilter = () => {
+    const queryFilter: QueryFilter = {
       query: { bool: { must: [] } },
     };
+    let setBoolObj: object = {};
 
-    // 초기화 클릭 or filter 선택을 모두 해제해서 초기화 누른거랑 동일한 환경
-    if (_.isEmpty(selectedFilters.value)) {
-      /**
-       * '초기화' 를 클릭했을때 searchResult 목록을 0부터 가지고 와야함.
-       * from 값을 0으로 설정하고 목록을 조회하면
-       *
-       * 1. from 0 -> api 조회
-       * 2. 1의 response 를 화면에 표시
-       * 3. 2의 동작으로 observer 가 동작 ( 내부에서 from += size ) 가 됨. -> from 5
-       * 4.
-       * 초기화 클릭했을때 searchResult 를 0부터 가지고 와야하는데
-       * from 을 0으로 놓고, 목록을 reload 하면,
-       * 1. from 0 으로 해서 api 조회
-       * 2. 1의 api 조회 response 값을 화면에 표시
-       * 3. 2의 동작으로 intersection-observer 가 동작 ( 여기서 from += size 가 됨 )
-       * 4. 3의 동작 callback으로 api 를 다시 조회 ( from 을 +SIZE_CNT 로 다시 호출 )
-       *
-       * 화면을 맨 처음 조회하는 경우, from 을 -SIZE_CNT 로 하면,
-       * -SIZE_CNT + SIZE_CNT 가 되어 0이 됨. api 호출을 2번 하지 않고 1번만 하고 끝남.
-       */
-      resetReloadList(-SIZE_CNT);
-    } else {
-      const setBoolObj: Ref<object> = ref<object>({});
-
-      for (const key in selectedFilters.value) {
-        const value = selectedFilters.value[key];
-        setBoolObj.value = setQueryFilterByDepth(key, value);
-        queryFilter.value.query.bool.must.push(setBoolObj.value);
-      }
+    for (const key in selectedFilters.value) {
+      const value = selectedFilters.value[key];
+      setBoolObj = setQueryFilterByDepth(key, value);
+      queryFilter.query.bool.must.push(setBoolObj);
     }
-
-    const isEmptyData = searchResult.value.length < 10;
-
-    // filter 값이 변경 되면, 조건을 리셋한다.
-    resetReloadList();
-
-    // TODO : intersection-observer 가 catch 하지 못할때의 데이터 로딩 처리 필요
-    // 확인한 내용으로는 filter 를 선택하여 목록의 갯수가 N개일때, filter 를 재조정 했을때 intersection-observer가 callback 함수를 실행하지 않아 목록을 더이상 갱신할 수 없는 부분이 있음.
-    // 그래서 N개 목록인 경우, 데이터 조회를 여기서 해준다.
-    // 기준은 10으로 잡음. 정확한 수치 알수 없음. 갯수 기준은 화면에 표시되는 갯수 기준 인것 같음. 확대/축소에 따라 다름.
-    if (isEmptyData) {
-      getSearchList();
-    }
+    return queryFilter;
   };
-  const resetReloadList = (count: number = 0) => {
-    setScrollFrom(count);
-    count < 0 ? (searchResult.value = []) : getSearchList(false);
+
+  /**
+   * 목록 reset
+   * 목록을 '갱신'하는 경우, from 값을 항상 0으로 주어야 하기 때문에 fn 하나로 묶어서 처리.
+   */
+  const resetReloadList = () => {
+    setScrollFrom(0);
+    updateIntersectionHandler(0);
+    getSearchList();
   };
   const setSortInfo = (item: string) => {
     const items = item.split("_");
     sortKey.value = items.shift() ?? ""; // undefined 오류 예외처리
     sortKeyOpt.value = items.pop() ?? "";
-    resetReloadList();
   };
   const setScrollFrom = (count: number) => {
     from.value = count;
-    // count 가 0 포함 이하 일때, handler 값을 갱신해준다. ( 초기화 등이 되어서 화면이 목록이 갱신되었기 때문 )
+  };
+  const updateIntersectionHandler = (count: number) => {
     if (count < 1) {
       if (intersectionHandler !== null) {
         intersectionHandler.updateChangingInitialCount(from.value);
+        intersectionHandler.scrollToFirElement();
       }
     }
   };
   const setSearchKeyword = (keyword: string) => {
-    searchKeyword.value = keyword;
-    // 검색 조건 리셋.
-    resetReloadList(0);
+    searchKeyword = keyword;
   };
   const setIntersectionHandler = (ih: any) => {
     intersectionHandler = ih;
@@ -319,14 +282,16 @@ export const useSearchCommonStore = defineStore("searchCommon", () => {
     isShowPreview,
     isBoxSelectedStyle,
     searchResultLength,
+    addSearchList,
     getSearchList,
     getFilters,
     getSearchDetails,
     getPreviewData,
-    setQueryFilter,
     setSortInfo,
     setScrollFrom,
     setSearchKeyword,
     setIntersectionHandler,
+    resetReloadList,
+    updateIntersectionHandler,
   };
 });

--- a/project/ovp/frontend/ovp/utils/intersection-observer.ts
+++ b/project/ovp/frontend/ovp/utils/intersection-observer.ts
@@ -47,8 +47,7 @@ export class IntersectionObserverHandler {
 
   // 목록이 reset 될때 (ex, filter 초기화 등) handler changingInitialCount 를 update 해준다.
   public updateChangingInitialCount(newChangingInitialCount: number) {
-    this.changingInitialCount =
-      newChangingInitialCount - this.boxItemDefaultCount;
+    this.changingInitialCount = newChangingInitialCount;
   }
 
   public disconnect() {

--- a/project/ovp/frontend/ovp/utils/intersection-observer.ts
+++ b/project/ovp/frontend/ovp/utils/intersection-observer.ts
@@ -45,9 +45,24 @@ export class IntersectionObserverHandler {
     });
   }
 
-  // 목록이 reset 될때 (ex, filter 초기화 등) handler changingInitialCount 를 update 해준다.
+  /**
+   * 목록이 갱신되었을때 netChangingInitialCount 를 reset 해주는 fn.
+   * @param newChangingInitialCount
+   */
   public updateChangingInitialCount(newChangingInitialCount: number) {
     this.changingInitialCount = newChangingInitialCount;
+  }
+
+  /**
+   * 목록이 갱신되었을때 scroll 을 첫번째 항목으로 보내는 fn.
+   */
+  public scrollToFirElement() {
+    const rootEl: any = this.observer.root;
+
+    if (rootEl.children.length > 0) {
+      const firChildEl: any = rootEl.firstElementChild;
+      rootEl.scrollTop = firChildEl.offsetTop;
+    }
   }
 
   public disconnect() {

--- a/project/ovp/server/src/main/java/com/mobigen/ovp/search/SearchService.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/search/SearchService.java
@@ -91,6 +91,7 @@ public class SearchService {
                 modifiedSource.put("firModelNm", source.get("displayName"));
                 modifiedSource.put("modelNm", source.get("name"));
                 modifiedSource.put("modelDesc", source.get("description"));
+                modifiedSource.put("fqn", source.get("fullyQualifiedName"));
 
                 String owner = "";
                 if (source.get("owner") != null) {


### PR DESCRIPTION
## 유형
- Feature (기능 추가 or 개선)

## 이슈 링크
- https://mobigen.atlassian.net/browse/FAB2023-898

## 수정 내용
- https://mobigen.atlassian.net/browse/FAB2023-903
- 탐색 목록 -> 상세 페이지 이동 구현
- header 검색어 처리 추가
- getSearchList query 중 from 관련 처리 수정


## TODO List
- [ ] header 검색어 제대로 동작하지 않음 
-> open meta 에서 index를 'table' 과 'container' 두개 붙여서 처리 하고 있는데 그런 경우 검색어 처리가 제대로 동작하지 않음. 