### PR TITLE
[FAB2023-1192] fix: userClient 기본 URL에 /users 추가로 인한 API 경로 수정

### DIFF
--- a/project/ovp/server/src/main/java/com/mobigen/ovp/user/UserClient.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/user/UserClient.java
@@ -17,7 +17,8 @@ import java.util.UUID;
 @FeignClient(name = "UserClient", url = "${properties.ovp.open-metadata-url}/users")
 public interface UserClient {
     @GetMapping("")
-    Map<String, Object> getUserAll(@RequestHeader HttpHeaders headers, @RequestParam Map<String, Object> param) throws Exception;
+    Map<String, Object> getUserAll(@RequestHeader HttpHeaders headers,
+                                   @RequestParam Map<String, Object> param) throws Exception;
 
     @GetMapping("/loggedInUser")
     Map<String, Object> getUserInfo() throws Exception;
@@ -25,17 +26,17 @@ public interface UserClient {
     @GetMapping("/{id}")
     Map<String, Object> getUserFollows(@PathVariable("id") String id, @RequestParam("fields") String fields);
 
-    @DeleteMapping("/users/{id}")
+    @DeleteMapping("/{id}")
     ResponseEntity<Void> deleteUser(@PathVariable UUID id,
                                     @RequestParam(defaultValue = "true") Boolean recursive,
                                     @RequestParam(defaultValue = "false") Boolean hardDelete);
 
-    @GetMapping("/users/generateRandomPwd")
+    @GetMapping("/generateRandomPwd")
     String getRandomPwd() throws Exception;
 
-    @GetMapping("/users/name/{name}")
+    @GetMapping("/name/{name}")
     Map<String, Object> checkDuplicateName(@PathVariable String name) throws Exception;
 
-    @PostMapping("/users")
+    @PostMapping("")
     Map<String, Object> addUser(@RequestBody Map<String, Object> param) throws Exception;
 }


### PR DESCRIPTION
## 유형
> 유형에 해당하는 항목 하나만 남기고 삭제
- Issue (버그 수정 등)

## 이슈 링크
- https://mobigen.atlassian.net/browse/FAB2023-1192
- https://mobigen.atlassian.net/browse/FAB2023-1194

## 수정 내용
- userClient 기본 URL에 /users 추가로 인한 API 경로 수정
