### PR TITLE
[FAB2023-1003] fix: 서비스 관리 저장소 설명 수정 활성화 상태가 다른 항목을 선택했을 때도 유지되어 열려있는 버그 처리

### DIFF
--- a/project/ovp/frontend/ovp/components/manage/service/repository.vue
+++ b/project/ovp/frontend/ovp/components/manage/service/repository.vue
@@ -4,6 +4,7 @@
     <editable-group
       compKey="repositoryDescription"
       :editable="true"
+      :parent-edit-mode="isDescEditable"
       @editCancel="editCancel"
       @editDone="editDone"
       @editIcon="editIconClick"
@@ -55,7 +56,8 @@ import agGrid from "@extends/grid/Grid.vue";
 import LinkDetailComponent from "./linkDetailComponent.vue";
 const serviceStore = useServiceStore();
 
-const { serviceData, DBServiceListData } = storeToRefs(serviceStore);
+const { serviceData, DBServiceListData, isDescEditable } =
+  storeToRefs(serviceStore);
 const { updateRepositoryDescriptionAPI } = serviceStore;
 
 interface RepositoryDescription {
@@ -103,6 +105,7 @@ const createJsonPatch = (oldData: any, newData: any): JsonPatchOperation[] => {
 // 수정 버튼 클릭 시 호출
 const editIconClick = () => {
   defaultData = _.cloneDeep(newData.value);
+  isDescEditable.value = true;
 };
 
 // 취소 버튼 클릭 시 호출

--- a/project/ovp/frontend/ovp/store/manage/service/index.ts
+++ b/project/ovp/frontend/ovp/store/manage/service/index.ts
@@ -48,6 +48,9 @@ export const useServiceStore = defineStore("service", () => {
     term: false,
   });
 
+  // 수정가능상태
+  const isDescEditable = ref<boolean>(false);
+
   const serviceData: Ref<ServiceData> = ref({ description: "" });
 
   const DBServiceListData: Ref<DBServiceListData[] | null | undefined> = ref([
@@ -163,6 +166,7 @@ export const useServiceStore = defineStore("service", () => {
    * @param source
    */
   function changeCurrentService(source: Service): void {
+    isDescEditable.value = false;
     if (!source.owner) {
       source.owner = [];
     }
@@ -472,5 +476,7 @@ export const useServiceStore = defineStore("service", () => {
     connectionInfo,
     viewConnectionInfo,
     getConnectionInfo,
+
+    isDescEditable,
   };
 });


### PR DESCRIPTION
## 유형
- Issue (버그 수정 등)

## 이슈 링크
- [FAB2023-1003](https://mobigen.atlassian.net/browse/FAB2023-1003)

## 수정 내용
- [FAB2023-1177](https://mobigen.atlassian.net/browse/FAB2023-1177)
- 서비스 관리 > 저장소 > 설명 수정 활성화 상태가 다른 항목을 선택했을 때도 유지되어 열려있는 버그 처리

[FAB2023-1003]: https://mobigen.atlassian.net/browse/FAB2023-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FAB2023-1177]: https://mobigen.atlassian.net/browse/FAB2023-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ