### PR TITLE
[FAB2023-1218] 데이터모델상세/ 태그목록에서openmetadata 기본 classification  PersonalData, Pll, Tier 안나오게 처리

### DIFF
--- a/project/ovp/server/src/main/java/com/mobigen/ovp/common/openmete_client/dto/Tag.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/common/openmete_client/dto/Tag.java
@@ -16,4 +16,5 @@ public class Tag {
     Map<String, Object> style;
     String labelType;
     String state;
+    Tag classification;
 }

--- a/project/ovp/server/src/main/java/com/mobigen/ovp/search_detail/SearchDetailService.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/search_detail/SearchDetailService.java
@@ -98,7 +98,10 @@ public class SearchDetailService {
         }
 
         Tags res = classificationClient.gatTags(params);
-        List<Tag> resTags = res.getData().stream().filter(tag -> !tag.getFullyQualifiedName().contains("ovp_category")).collect(Collectors.toList());
+        List<Tag> resTags = res.getData().stream().filter(tag -> {
+            String classificationName = tag.getClassification().getName();
+            return !(classificationName.contains("ovp_category") || classificationName.contains("PersonalData") || classificationName.contains("Pll") || classificationName.contains("Tier"));
+        }).collect(Collectors.toList());
 
 
         List<Tag> mergeTagList = Stream.concat(tags.stream(), resTags.stream()).collect(Collectors.toList());
@@ -238,6 +241,7 @@ public class SearchDetailService {
 
     /**
      * 데이터 모델 상세 > 팔로우(북마크) 데이터 추출
+     *
      * @param userId
      * @param id
      * @param type
@@ -254,7 +258,7 @@ public class SearchDetailService {
                 ? containersClient.getStorageById(id, params)
                 : tablesClient.getTablesName(id, params);
 
-        for(Followers followers: resultData.getFollowers()) {
+        for (Followers followers : resultData.getFollowers()) {
             if (followers.getId().equals(userId)) {
                 isFollow = true;
                 break;


### PR DESCRIPTION
## 유형
- Issue (버그 수정 등)

## 이슈 링크
- [FAB2023-1218](https://mobigen.atlassian.net/browse/FAB2023-1218)

## 수정 내용
- [FAB2023-1218](https://mobigen.atlassian.net/browse/FAB2023-1218)

[FAB2023-1218]: https://mobigen.atlassian.net/browse/FAB2023-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FAB2023-1218]: https://mobigen.atlassian.net/browse/FAB2023-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ