### PR TITLE
[FAB-2023-1157] fix : 미분류 카테고리가 설정된 데이터 모델 조회 오류 수정 및 상수처리

### DIFF
--- a/project/ovp/server/src/main/java/com/mobigen/ovp/category/CategoryService.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/category/CategoryService.java
@@ -3,6 +3,7 @@ package com.mobigen.ovp.category;
 import com.mobigen.ovp.category.dto.CategoryDTO;
 import com.mobigen.ovp.category.entity.CategoryEntity;
 import com.mobigen.ovp.category.repository.CategoryRepository;
+import com.mobigen.ovp.common.constants.Constants;
 import com.mobigen.ovp.common.constants.ModelType;
 import com.mobigen.ovp.common.openmete_client.ClassificationClient;
 import com.mobigen.ovp.common.openmete_client.ContainersClient;
@@ -40,10 +41,6 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final SearchService searchService;
     private final ClassificationClient classificationClient;
-
-    private static final String OVP_CATEGORY = "ovp_category";
-    private static final String UNDEFINED_TAG_NAME = "미분류";
-
 
     public CategoryDTO getCategories() {
         List<CategoryEntity> categories = categoryRepository.findAll();
@@ -101,7 +98,7 @@ public class CategoryService {
     public Object insertOrUpdate(CategoryDTO dto) throws Exception {
         CategoryEntity undefinedTagEntity = getUndefinedTag();
 
-        if (undefinedTagEntity != null && dto.getName().equals(UNDEFINED_TAG_NAME)) {
+        if (undefinedTagEntity != null && dto.getName().equals(Constants.UNDEFINED_TAG_NAME)) {
             return "NOT_ALLOWED_NAME";
         }
         if (undefinedTagEntity != null && dto.getParentId().equals(undefinedTagEntity.getId().toString())) {
@@ -349,7 +346,7 @@ public class CategoryService {
     // TODO : classification 명 상수 처리 필요.
     public String createTagInfo(String categoryId) {
         Map<String, Object> params = new HashMap<>();
-        params.put("classification", OVP_CATEGORY);
+        params.put("classification", Constants.OVP_CATEGORY);
         params.put("description", "OVP Category Matched Tag");
         params.put("displayName", categoryId);
         params.put("name", categoryId);
@@ -396,12 +393,12 @@ public class CategoryService {
 
         // 데이터 모델의 태크 목록에서 카테고리, 태그, 용어를 분리해서 저장.
         List<DataModelDetailTagDto> glossaryList = tags.stream()
-                .filter(tag -> !tag.getTagFQN().contains(OVP_CATEGORY) && "Glossary".equals(tag.getSource()))
+                .filter(tag -> !tag.getTagFQN().contains(Constants.OVP_CATEGORY) && "Glossary".equals(tag.getSource()))
                 .map(tag -> new DataModelDetailTagDto(tag))
                 .collect(Collectors.toList());
         ;
         List<DataModelDetailTagDto> classificationList = tags.stream()
-                .filter(tag -> !tag.getTagFQN().contains(OVP_CATEGORY) && "Classification".equals(tag.getSource()))
+                .filter(tag -> !tag.getTagFQN().contains(Constants.OVP_CATEGORY) && "Classification".equals(tag.getSource()))
                 .map(tag -> new DataModelDetailTagDto(tag))
                 .collect(Collectors.toList());
 
@@ -474,6 +471,6 @@ public class CategoryService {
     }
 
     private CategoryEntity getUndefinedTag() {
-        return categoryRepository.findByName(UNDEFINED_TAG_NAME);
+        return categoryRepository.findByName(Constants.UNDEFINED_TAG_NAME);
     }
 }

--- a/project/ovp/server/src/main/java/com/mobigen/ovp/category/repository/CategoryRepository.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/category/repository/CategoryRepository.java
@@ -71,4 +71,6 @@ public interface CategoryRepository extends JpaRepository<CategoryEntity, UUID> 
     List<CategoryEntity> findByParentIdAndIdNotAndName(@Param("parentId") UUID parentId, @Param("id") UUID id, @Param("name") String name);
 
     CategoryEntity findByName(@Param("name") String categoryName);
+
+    CategoryEntity findByTagId(@Param("id") UUID tagId);
 }

--- a/project/ovp/server/src/main/java/com/mobigen/ovp/common/ModelConvertUtil.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/common/ModelConvertUtil.java
@@ -2,6 +2,7 @@ package com.mobigen.ovp.common;
 
 import com.mobigen.ovp.category.entity.CategoryEntity;
 import com.mobigen.ovp.category.repository.CategoryRepository;
+import com.mobigen.ovp.common.constants.Constants;
 import com.mobigen.ovp.common.constants.ModelType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -114,8 +115,8 @@ public class ModelConvertUtil {
                     tag.put("displayName", displayName);
                 }
 
-                if (tag.get("tagFQN").toString().contains("ovp_category")) {
-                    CategoryEntity categoryEntity = categoryRepository.findByIdWithParent(UUID.fromString(tag.get("name").toString()));
+                if (tag.get("tagFQN").toString().contains(Constants.OVP_CATEGORY)) {
+                    CategoryEntity categoryEntity = getCategoryEntity(tag.get("name").toString());
                     if (categoryEntity != null) {
                         Map<String, Object> category = (Map<String, Object>) modifiedSource.get("category");
                         category.put("id", categoryEntity.getId());
@@ -131,6 +132,15 @@ public class ModelConvertUtil {
         }
 
         return modifiedSource;
+    }
+
+    // TODO : [개발] 추후에 카테고리 DB 정리하면서 아래 코드 수정 필요함.
+    public CategoryEntity getCategoryEntity(String tagName) {
+        if (tagName.equals(Constants.UNDEFINED_TAG_NAME)) {
+            return categoryRepository.findByName(tagName);
+        } else {
+            return categoryRepository.findByTagId(UUID.fromString(tagName));
+        }
     }
 
 

--- a/project/ovp/server/src/main/java/com/mobigen/ovp/common/constants/Constants.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/common/constants/Constants.java
@@ -1,0 +1,10 @@
+package com.mobigen.ovp.common.constants;
+
+public class Constants {
+    public static final String OVP_CATEGORY = "ovp_category";
+    public static final String UNDEFINED_TAG_NAME = "미분류";
+
+    private Constants() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+}

--- a/project/ovp/server/src/main/java/com/mobigen/ovp/search/SearchService.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/search/SearchService.java
@@ -1,5 +1,6 @@
 package com.mobigen.ovp.search;
 
+import com.mobigen.ovp.common.constants.Constants;
 import com.mobigen.ovp.common.ModelConvertUtil;
 import com.mobigen.ovp.common.entity.ModelIndex;
 import com.mobigen.ovp.common.openmete_client.SearchClient;
@@ -50,7 +51,7 @@ public class SearchService {
                         }
                     } else if (newKey.equals("tags.tagFQN") && buckets instanceof List) {
                         List<Map<String, Object>> filteredBuckets = ((List<Map<String, Object>>) buckets).stream()
-                                .filter(bucket -> !((String) bucket.get("key")).contains("ovp_category."))
+                                .filter(bucket -> !((String) bucket.get("key")).contains(Constants.OVP_CATEGORY + "."))
                                 .collect(Collectors.toList());
                         if (!filteredBuckets.isEmpty()) {
                             resultMap.put(newKey, filteredBuckets);
@@ -156,7 +157,7 @@ public class SearchService {
     private Map<String, Object> getList(MultiValueMap<String, String> params) throws Exception {
         return getList(params, false);
     }
-    
+
     private Map<String, Object> getList(MultiValueMap<String, String> params, Boolean useFilter) throws Exception {
         Map<String, Object> result = searchClient.getSearchList(params);
         return convertToMap(result, useFilter);

--- a/project/ovp/server/src/main/java/com/mobigen/ovp/search_detail/SearchDetailService.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/search_detail/SearchDetailService.java
@@ -2,6 +2,8 @@ package com.mobigen.ovp.search_detail;
 
 import com.mobigen.ovp.category.entity.CategoryEntity;
 import com.mobigen.ovp.category.repository.CategoryRepository;
+import com.mobigen.ovp.common.constants.Constants;
+import com.mobigen.ovp.common.ModelConvertUtil;
 import com.mobigen.ovp.common.constants.ModelType;
 import com.mobigen.ovp.common.openmete_client.ClassificationClient;
 import com.mobigen.ovp.common.openmete_client.ContainersClient;
@@ -54,6 +56,7 @@ public class SearchDetailService {
 
     private final UserService userService;
     private final CategoryRepository categoryRepository;
+    private final ModelConvertUtil modelConvertUtil;
 
     /**
      * 사용자 목록 (전체)
@@ -219,8 +222,8 @@ public class SearchDetailService {
                 tag.setDisplayName(displayName);
             }
 
-            if (tag.getTagFQN().contains("ovp_category")) {
-                CategoryEntity categoryEntity = categoryRepository.findByIdWithParent(UUID.fromString(tag.getName()));
+            if (tag.getTagFQN().contains(Constants.OVP_CATEGORY)) {
+                CategoryEntity categoryEntity = modelConvertUtil.getCategoryEntity(tag.getName());
                 if (categoryEntity != null) {
                     dataModelDetailResponse.getCategory().setId(categoryEntity.getId());
                     dataModelDetailResponse.getCategory().setName(categoryEntity.getName());
@@ -458,16 +461,16 @@ public class SearchDetailService {
 
         // 데이터 모델의 태크 목록에서 카테고리, 태그, 용어를 분리해서 저장.
         List<DataModelDetailTagDto> glossaryList = tags.stream()
-                .filter(tag -> !tag.getTagFQN().contains("ovp_category") && "Glossary".equals(tag.getSource()))
+                .filter(tag -> !tag.getTagFQN().contains(Constants.OVP_CATEGORY) && "Glossary".equals(tag.getSource()))
                 .map(tag -> new DataModelDetailTagDto(tag))
                 .collect(Collectors.toList());
         ;
         List<DataModelDetailTagDto> classificationList = tags.stream()
-                .filter(tag -> !tag.getTagFQN().contains("ovp_category") && "Classification".equals(tag.getSource()))
+                .filter(tag -> !tag.getTagFQN().contains(Constants.OVP_CATEGORY) && "Classification".equals(tag.getSource()))
                 .map(tag -> new DataModelDetailTagDto(tag))
                 .collect(Collectors.toList());
         List<DataModelDetailTagDto> categoryList = tags.stream()
-                .filter(tag -> tag.getTagFQN().contains("ovp_category") && "Classification".equals(tag.getSource()))
+                .filter(tag -> tag.getTagFQN().contains(Constants.OVP_CATEGORY) && "Classification".equals(tag.getSource()))
                 .map(tag -> new DataModelDetailTagDto(tag))
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## 유형
- Issue (버그 수정 등)

## 이슈 링크
- https://mobigen.atlassian.net/browse/FAB2023-1157

## 수정 내용
- - '미분류' string 을 UUID 로 조회해서 발생하는 오류 수정
- 'ovp_category'', '미분류' 상수처리