### PR TITLE
[FAB2023-1218] fix: 탐색/ 다른 탭 이동 후 페이지 다시 들어 올떼 초기 탬과 데이터가 불일치 되는 문제 수정

### DIFF
--- a/project/ovp/frontend/ovp/pages/portal/search/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/search/index.vue
@@ -172,6 +172,10 @@ watchEffect(() => {
 
 await getFilters();
 
+onBeforeMount(() => {
+  changeTab("table");
+});
+
 onBeforeRouteLeave((to, from, next) => {
   isShowPreview.value = false;
   setEmptyFilter();


### PR DESCRIPTION
## 유형
- Issue (버그 수정 등)

## 이슈 링크
- [FAB2023-1218](https://mobigen.atlassian.net/browse/FAB2023-1218)

## 수정 내용
- [FAB2023-1218](https://mobigen.atlassian.net/browse/FAB2023-1218)