### PR TITLE
[FAB2023-1220] 사용성 테스트 버전 버그 수정

### DIFF
--- a/project/ovp/frontend/ovp/pages/portal/govern/category/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/govern/category/index.vue
@@ -309,6 +309,7 @@ const onCategoryNodeClick = async (node: TreeViewItem) => {
   dupliSelectedTitleNodeValue.value = node.name;
   selectedCategoryId.value = node.id;
   selectedCategoryTagId.value = <string>node.tagId;
+  searchInputValue.value = "";
   checkModalButton(node);
   setScrollOptions(0);
   // 선택한 노드정보 저장
@@ -320,6 +321,8 @@ const onCategoryNodeClick = async (node: TreeViewItem) => {
 };
 
 const getAllModelList = async () => {
+  isAllModelListChecked.value = false;
+  selectedModelList.value = [];
   setScrollOptions(0);
   setSelectedNode(selectedNodeCategory.value);
   await getModelList();
@@ -437,9 +440,12 @@ const searchInputValue = ref("");
 const updateSearchInputValue = (newValue: string) => {
   searchInputValue.value = newValue;
 };
-const onInput = (value: string) => {
+const onInput = async (value: string) => {
+  isAllModelListChecked.value = false;
+  selectedModelList.value = [];
   setScrollOptions(0);
-  getModelList(value);
+  await getModelList(value);
+  setModelIdList();
 };
 
 const checked = (checkedList: any[]) => {

--- a/project/ovp/frontend/ovp/pages/portal/govern/category/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/govern/category/index.vue
@@ -240,6 +240,7 @@ const {
   changeTab,
   setEmptyFilter,
   setModelIdList,
+  setSelectedNode,
   undefinedTagIdManager,
 } = categoryStore;
 const {


### PR DESCRIPTION
## 유형
> 유형에 해당하는 항목 하나만 남기고 삭제
- Issue (버그 수정 등)

## 이슈 링크
- https://mobigen.atlassian.net/browse/FAB2023-1220
- https://mobigen.atlassian.net/browse/FAB2023-1213

## 수정 내용
- 20240906_14 (목록은 검색어를 입력하면 엔터 또는 버튼 클릭 없이 실시간으로 검색 결과가 조회되는 방식으로 구현되어 있음.
검색어 입력 후 X 버튼을 클릭하면 입력값만 삭제되고 전체 목록이 조회되지 않음)
- 20240906_15 (하나의 카테고리에서 검색어 입력후 다른 카테고리로 넘어갔을때 검색어가 유지되어 있음(검색어에 대한 조회는 안됨))
- 20240906_16 (전체선택 후 검색어 입력 or 검색어 입력 후 전체선택 시, 데이터 목록 체크가 정상적으로 동작하지 않음.)