### PR TITLE
feat: 용어/태그 선택 목록에 상위 depth 도 표시

### DIFF
--- a/project/ovp/frontend/common/components/extends/common/interfaces/props/Select.interface.ts
+++ b/project/ovp/frontend/common/components/extends/common/interfaces/props/Select.interface.ts
@@ -3,10 +3,10 @@ export interface SelectProps {
   data: { [key: string]: string | number }[];
   labelKey: string;
   valueKey: string;
+  selectedLabelKey?: string;
   iconKey?: string;
   defaultLabel?: string;
   selectedItem?: string | number;
   disabledList?: (string | number)[];
   isFirstSelectedEvent?: boolean;
 }
-

--- a/project/ovp/frontend/common/components/extends/menu-seach/tag/menu-search-tag.vue
+++ b/project/ovp/frontend/common/components/extends/menu-seach/tag/menu-search-tag.vue
@@ -4,7 +4,7 @@
       <button class="select-button" @click.stop="onClickOpenMenuSearch">
         <span class="select-button-title" v-if="selectedListData.length < 1">{{ props.title }}</span>
         <div class="tag tag-primary tag-sm" v-else v-for="item in selectedListData">
-          <span class="tag-text">{{ item[props.labelKey] }}</span>
+          <span class="tag-text">{{ item[props.selectedLabelKey || props.labelKey] }}</span>
           <button class="tag-delete-button" @click.stop="onDeleteTag(item)">
             <span class="hidden-text">삭제</span>
             <svg-icon class="svg-icon" name="close"></svg-icon>
@@ -36,6 +36,7 @@ import MenuSearch from "../menu-search.vue";
 
 const props = withDefaults(defineProps<MenuSearchTypeProps>(), {
   data: () => [],
+  selectedLabelKey: "",
   labelKey: "label",
   valueKey: "value",
   iconKey: "icon",

--- a/project/ovp/frontend/ovp/components/datamodel-creation/modal/save.vue
+++ b/project/ovp/frontend/ovp/components/datamodel-creation/modal/save.vue
@@ -89,7 +89,8 @@
               <menu-search-tag
                 :data="tagList"
                 :selected-items="tag_selectedItem"
-                label-key="displayName"
+                selected-label-key="displayName"
+                label-key="tagFQN"
                 value-key="tagFQN"
                 :is-multi="true"
                 title="태그 없음"
@@ -131,6 +132,7 @@ import { useDataModelSaveStore } from "~/store/datamodel-creation/save";
 import MenuSearchTree from "@extends/menu-seach/tree/menu-search-tree.vue";
 import MenuSearchTag from "@extends/menu-seach/tag/menu-search-tag.vue";
 import $constants from "~/utils/constant";
+
 const dataModelSaveStore = useDataModelSaveStore();
 
 const {

--- a/project/ovp/frontend/ovp/components/govern/glossary/modal/modal-glossary-dictionary.vue
+++ b/project/ovp/frontend/ovp/components/govern/glossary/modal/modal-glossary-dictionary.vue
@@ -96,7 +96,7 @@
                   :selected-items="glossaryForm.tags"
                   :is-multi="true"
                   :is-show="isShowMenuSearch"
-                  label-key="displayName"
+                  label-key="tagFQN"
                   value-key="tagFQN"
                   @cancel="showMenuSearch(false)"
                   @multiple-change="changeTag"

--- a/project/ovp/frontend/ovp/components/govern/glossary/modal/modal-glossary.vue
+++ b/project/ovp/frontend/ovp/components/govern/glossary/modal/modal-glossary.vue
@@ -96,7 +96,7 @@
                   :selected-items="termForm.tags"
                   :is-multi="true"
                   :is-show="isShowMenuSearch.tag"
-                  label-key="displayName"
+                  label-key="tagFQN"
                   value-key="tagFQN"
                   @cancel="showMenuSearch(false, 'tag')"
                   @multiple-change="changeTag"

--- a/project/ovp/frontend/ovp/components/search/detail-tab/default-info.vue
+++ b/project/ovp/frontend/ovp/components/search/detail-tab/default-info.vue
@@ -65,11 +65,15 @@
               <svg-icon class="button-icon" name="pen"></svg-icon>
             </button>
           </div>
-          <div class="editable-group editable-group-unusual" v-if="editTagsMode">
+          <div
+            class="editable-group editable-group-unusual"
+            v-if="editTagsMode"
+          >
             <menu-search-tag
               :data="tagList"
               :selected-items="mdoelTagList"
-              label-key="displayName"
+              selected-label-key="displayName"
+              label-key="tagFQN"
               value-key="tagFQN"
               :is-multi="true"
               title="값을 선택하세요"
@@ -128,11 +132,15 @@
               <svg-icon class="button-icon" name="pen"></svg-icon>
             </button>
           </div>
-          <div class="editable-group editable-group-unusual" v-if="editTermsMode">
+          <div
+            class="editable-group editable-group-unusual"
+            v-if="editTermsMode"
+          >
             <menu-search-tag
               :data="termList"
               :selected-items="dataModel.terms"
-              label-key="displayName"
+              selected-label-key="displayName"
+              label-key="tagFQN"
               value-key="tagFQN"
               :is-multi="true"
               title="값을 선택하세요"


### PR DESCRIPTION
## 유형
- Feature (기능 추가 or 개선)

## 수정 내용
- 탐색 상세 > 기본정보 태그/용어 선택 목록에 상위 depth 표시
- 용어사전 > 용어사전 추가 태그 목록에 상위 depth 표시
- 용어사전 > 용어 추가 태그 목록에 상위 depth 표시
- 데이터 모델 생성 > 데이터 모델 저장 태그 목록에 상위 depth 표시
