### PR TITLE
[FAB2023-1345] 리소스박스내에 미리보기 / 상세보기 버튼기능 추가

### DIFF
--- a/project/ovp/frontend/ovp/components/common/resource-box/resource-box-common-props.ts
+++ b/project/ovp/frontend/ovp/components/common/resource-box/resource-box-common-props.ts
@@ -14,6 +14,7 @@ export interface DataModel {
 
 export interface ResourceBoxCommonProps {
   usePrvBtn?: boolean;
+  useDetailBtn?: boolean;
   showOwner?: boolean;
   showCategory?: boolean;
   useFirModelNm?: boolean;

--- a/project/ovp/frontend/ovp/components/common/resource-box/resource-box-list.vue
+++ b/project/ovp/frontend/ovp/components/common/resource-box/resource-box-list.vue
@@ -33,7 +33,7 @@ const selectedList: Ref<Array<string | number>> = ref([]);
 const selectedResourceBoxId: Ref<string | number> = ref("");
 
 const props = withDefaults(defineProps<ResourceBoxListProps>(), {
-  usePrvBtn: true,
+  usePrvBtn: false,
   useFirModelNm: false,
   useListCheckbox: false,
   useDataNmLink: true,

--- a/project/ovp/frontend/ovp/components/common/resource-box/resource-box-list.vue
+++ b/project/ovp/frontend/ovp/components/common/resource-box/resource-box-list.vue
@@ -13,27 +13,28 @@
       :showOwner="props.showOwner"
       :showCategory="props.showCategory"
       :use-prv-btn="props.usePrvBtn"
+      :use-detail-btn="props.useDetailBtn"
       :useFirModelNm="props.useFirModelNm"
       :use-data-nm-link="props.useDataNmLink"
       :selected-model-list="props.selectedModelList"
       @checked="checked"
       @previewClick="previewClick"
-      @modelNmClick="modelNmClick"
+      @open-detail-page="openDetailPage"
     />
   </template>
 </template>
 
 <script setup lang="ts">
-import ResourceBox from "~/components/common/resource-box/resource-box.vue";
+import ResourceBox from "@/components/common/resource-box/resource-box.vue";
 import { defineEmits, ref, watch } from "vue";
 import type { ResourceBoxListProps } from "./resource-box-list-props";
-import _ from "lodash";
 
 const selectedList: Ref<Array<string | number>> = ref([]);
 const selectedResourceBoxId: Ref<string | number> = ref("");
 
 const props = withDefaults(defineProps<ResourceBoxListProps>(), {
   usePrvBtn: false,
+  useDetailBtn: false,
   useFirModelNm: false,
   useListCheckbox: false,
   useDataNmLink: true,
@@ -44,7 +45,7 @@ const props = withDefaults(defineProps<ResourceBoxListProps>(), {
 
 const emit = defineEmits<{
   (e: "previewClick", data: object): void;
-  (e: "modelNmClick", data: object): void;
+  (e: "openDetailPage", data: object): void;
   (e: "checkedValueChanged", ids: any[]): void;
 }>();
 
@@ -52,10 +53,6 @@ const previewClick = (data: object) => {
   const { id } = data as { id: string };
   selectedResourceBoxId.value = id;
   emit("previewClick", data);
-};
-
-const modelNmClick = (data: object) => {
-  emit("modelNmClick", data);
 };
 
 const checked = ({
@@ -77,6 +74,19 @@ const checked = ({
 
   emit("checkedValueChanged", selectedList.value);
 };
+
+function openDetailPage(data: object) {
+  const { id, fqn, type } = data as { id: string; fqn: string; type: string };
+  const queryParams = new URLSearchParams({
+    type,
+    id,
+    fqn,
+  }).toString();
+
+  const fullPath = `/portal/search/detail?${queryParams}`;
+
+  window.open(fullPath, "_blank", "noopener,noreferrer");
+}
 
 watch(
   () => props.selectedModelList,

--- a/project/ovp/frontend/ovp/components/common/resource-box/resource-box.vue
+++ b/project/ovp/frontend/ovp/components/common/resource-box/resource-box.vue
@@ -282,6 +282,7 @@
         </template>
       </editable-group>
     </div>
+    <button v-show="props.usePrvBtn" @click="previewClick">미리보기</button>
   </div>
 </template>
 
@@ -317,6 +318,7 @@ const props = withDefaults(defineProps<ResourceBoxProps>(), {
     return {};
   },
   useContextBox: false,
+  usePrvBtn: false,
 });
 
 const isChecked = computed(() => {

--- a/project/ovp/frontend/ovp/components/common/resource-box/resource-box.vue
+++ b/project/ovp/frontend/ovp/components/common/resource-box/resource-box.vue
@@ -283,6 +283,7 @@
       </editable-group>
     </div>
     <button v-show="props.usePrvBtn" @click="previewClick">미리보기</button>
+    <button v-show="props.useDetailBtn" @click="openDetailPage">상세보기</button>
   </div>
 </template>
 
@@ -319,6 +320,7 @@ const props = withDefaults(defineProps<ResourceBoxProps>(), {
   },
   useContextBox: false,
   usePrvBtn: false,
+  useDetailBtn: false,
 });
 
 const isChecked = computed(() => {
@@ -345,7 +347,7 @@ const newData: ComputedRef<DataModel> = computed(() => {
 
 const emit = defineEmits<{
   (e: "previewClick", data: object): void;
-  (e: "modelNmClick", data: object): void;
+  (e: "openDetailPage", data: object): void;
   (e: "checked", data: any): void;
   (e: "editIconClick", id: string): void;
   (e: "editDoneForModel", data: object): void;
@@ -357,9 +359,16 @@ const previewClick = () => {
     emit("previewClick", props.dataObj);
   }
 };
+
 const modelNmClick = () => {
-  emit("modelNmClick", props.dataObj);
+  emit("openDetailPage", props.dataObj);
 };
+
+const openDetailPage = () => {
+  if(props.useDetailBtn) {
+    modelNmClick();
+  }
+}
 
 const editCancel = (key: string) => {
   tempData.value[key] = newData.value[key];

--- a/project/ovp/frontend/ovp/components/datamodel-creation/modal/add.vue
+++ b/project/ovp/frontend/ovp/components/datamodel-creation/modal/add.vue
@@ -54,7 +54,8 @@
                   :show-category="true"
                   :use-data-nm-link="true"
                   :use-context-box="false"
-                  @model-nm-click="clickRecommendDataModel"
+                  :use-detail-btn="true"
+                  @open-detail-page="openDetailPage"
                 />
               </template>
             </div>
@@ -84,6 +85,7 @@ import AddDetailGrid from "~/components/datamodel-creation/modal/add-detail-grid
 import RecommendModel from "@/components/search/detail-tab/recommend-model.vue";
 
 import { useRouter } from "nuxt/app";
+import ResourceBox from "~/components/common/resource-box/resource-box.vue";
 
 const router = useRouter();
 
@@ -147,19 +149,18 @@ const onCloseModal = () => {
   infiniteScrollSettingDone.value = false;
 };
 
-const clickRecommendDataModel = (data: object) => {
+function openDetailPage(data: object) {
   const { id, fqn, type } = data as { id: string; fqn: string; type: string };
-
   const queryParams = new URLSearchParams({
     type,
     id,
     fqn,
   }).toString();
 
-  const detailPath = "/portal/search/detail";
-  const fullPath = `${detailPath}?${queryParams}`;
+  const fullPath = `/portal/search/detail?${queryParams}`;
 
   window.open(fullPath, "_blank", "noopener,noreferrer");
-};
+}
+
 </script>
 <style lang="scss" scoped></style>

--- a/project/ovp/frontend/ovp/components/search/detail-tab/knowledge-graph.vue
+++ b/project/ovp/frontend/ovp/components/search/detail-tab/knowledge-graph.vue
@@ -145,6 +145,8 @@
           :show-owner="true"
           :show-category="true"
           :use-data-nm-link="true"
+          :use-detail-btn="true"
+          @open-detail-page="openDetailPage"
         />
       </template>
       <!-- resource-box 끝  -->
@@ -155,6 +157,9 @@
 <script setup lang="ts">
 import ResourceBox from "@/components/common/resource-box/resource-box.vue";
 import imageSrc from "@/assets/images/knowledge-graph-sample.jpg";
+import { useRoute, useRouter } from "nuxt/app";
+const router = useRouter();
+const route = useRoute();
 
 const isLegendVisible = ref(true);
 
@@ -173,6 +178,19 @@ let resourceBoxObj: any = {
   owner: "장소라",
   category: "카테고리",
 };
+
+function openDetailPage(data: object) {
+  const { id, fqn, type } = data as { id: string; fqn: string; type: string };
+  const queryParams = new URLSearchParams({
+    type,
+    id,
+    fqn,
+  }).toString();
+
+  const fullPath = `/portal/search/detail?${queryParams}`;
+
+  window.open(fullPath, "_blank", "noopener,noreferrer");
+}
 </script>
 
 <style lang="scss" scoped>

--- a/project/ovp/frontend/ovp/components/search/detail-tab/recommend-model.vue
+++ b/project/ovp/frontend/ovp/components/search/detail-tab/recommend-model.vue
@@ -28,6 +28,7 @@
 import { useDataModelDetailStore } from "@/store/search/detail";
 import { storeToRefs } from "pinia";
 import { useRouter, useRoute } from "nuxt/app";
+import ResourceBox from "@/components/common/resource-box/resource-box.vue";
 const dataModelDetailStore = useDataModelDetailStore();
 const { recommendDataModels } = storeToRefs(dataModelDetailStore);
 const router = useRouter();

--- a/project/ovp/frontend/ovp/components/search/detail-tab/recommend-model.vue
+++ b/project/ovp/frontend/ovp/components/search/detail-tab/recommend-model.vue
@@ -10,7 +10,8 @@
             :show-owner="true"
             :show-category="true"
             :use-data-nm-link="true"
-            @model-nm-click="clickRecommendDataModel"
+            :use-detail-btn="true"
+            @open-detail-page="openDetailPage"
           />
         </template>
       </div>
@@ -27,12 +28,9 @@
 <script setup lang="ts">
 import { useDataModelDetailStore } from "@/store/search/detail";
 import { storeToRefs } from "pinia";
-import { useRouter, useRoute } from "nuxt/app";
 import ResourceBox from "@/components/common/resource-box/resource-box.vue";
 const dataModelDetailStore = useDataModelDetailStore();
 const { recommendDataModels } = storeToRefs(dataModelDetailStore);
-const router = useRouter();
-const route = useRoute();
 
 const groupedRecommendations = computed(() => {
   const groups = [];
@@ -42,7 +40,7 @@ const groupedRecommendations = computed(() => {
   return groups;
 });
 
-function clickRecommendDataModel(data: object) {
+function openDetailPage(data: object) {
   const { id, fqn, type } = data as { id: string; fqn: string; type: string };
   const queryParams = new URLSearchParams({
     type,
@@ -50,10 +48,11 @@ function clickRecommendDataModel(data: object) {
     fqn,
   }).toString();
 
-  const fullPath = `${route.path}?${queryParams}`;
+  const fullPath = `/portal/search/detail?${queryParams}`;
 
   window.open(fullPath, "_blank", "noopener,noreferrer");
 }
+
 </script>
 
 <style lang="scss" scoped></style>

--- a/project/ovp/frontend/ovp/pages/index.vue
+++ b/project/ovp/frontend/ovp/pages/index.vue
@@ -23,7 +23,6 @@
           </div>
           <resource-box-list
             v-else
-            :use-prv-btn="false"
             :data-list="upVotesData"
             :use-list-checkbox="false"
             :show-owner="true"
@@ -53,7 +52,6 @@
         </div>
         <resource-box-list
           v-else
-          :use-prv-btn="false"
           :data-list="lastUpdatedData"
           :use-list-checkbox="false"
           :show-owner="true"
@@ -80,7 +78,6 @@
         </div>
         <resource-box-list
           v-else
-          :use-prv-btn="false"
           :data-list="bookmarkData"
           :use-list-checkbox="false"
           :show-owner="true"

--- a/project/ovp/frontend/ovp/pages/index.vue
+++ b/project/ovp/frontend/ovp/pages/index.vue
@@ -28,7 +28,8 @@
             :show-owner="true"
             :show-category="true"
             :is-box-selected-style="false"
-            @modelNmClick="modelNmClick"
+            :use-detail-btn="true"
+            @open-detail-page="openDetailPage"
           />
         </div>
       </div>
@@ -130,17 +131,18 @@ const setSearchConditionUrl = (item: string) => {
   });
 };
 
-const modelNmClick = (data: object) => {
+function openDetailPage(data: object) {
   const { id, fqn, type } = data as { id: string; fqn: string; type: string };
-  router.push({
-    path: "/portal/search/detail",
-    query: {
-      id: id,
-      fqn: fqn,
-      type: type,
-    },
-  });
-};
+  const queryParams = new URLSearchParams({
+    type,
+    id,
+    fqn,
+  }).toString();
+
+  const fullPath = `/portal/search/detail?${queryParams}`;
+
+  window.open(fullPath, "_blank", "noopener,noreferrer");
+}
 
 onMounted(() => {
   if (loader.value) {

--- a/project/ovp/frontend/ovp/pages/portal/govern/category/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/govern/category/index.vue
@@ -194,9 +194,11 @@
                     :show-owner="true"
                     :show-category="true"
                     :use-prv-btn="true"
+                    :use-detail-btn="true"
                     :is-box-selected-style="isBoxSelectedStyle"
                     :selected-model-list="selectedModelList"
                     @modelNmClick="modelNmClick"
+                    @open-detail-page="openDetailPage"
                     @previewClick="previewClick"
                     @checkedValueChanged="checked"
                   />
@@ -500,17 +502,18 @@ const previewClick = async (data: object) => {
   previewIndex = type;
 };
 
-const modelNmClick = (data: object) => {
+function openDetailPage(data: object) {
   const { id, fqn, type } = data as { id: string; fqn: string; type: string };
-  router.push({
-    path: "/portal/search/detail",
-    query: {
-      type: type,
-      id: id,
-      fqn: fqn,
-    },
-  });
-};
+  const queryParams = new URLSearchParams({
+    type,
+    id,
+    fqn,
+  }).toString();
+
+  const fullPath = `/portal/search/detail?${queryParams}`;
+
+  window.open(fullPath, "_blank", "noopener,noreferrer");
+}
 
 // EDITABLE-INPUT
 const editCancel = (key: string) => {

--- a/project/ovp/frontend/ovp/pages/portal/govern/category/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/govern/category/index.vue
@@ -193,6 +193,7 @@
                     :use-list-checkbox="true"
                     :show-owner="true"
                     :show-category="true"
+                    :use-prv-btn="true"
                     :is-box-selected-style="isBoxSelectedStyle"
                     :selected-model-list="selectedModelList"
                     @modelNmClick="modelNmClick"

--- a/project/ovp/frontend/ovp/pages/portal/my-page/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/my-page/index.vue
@@ -44,6 +44,7 @@
               :use-list-checkbox="false"
               :show-owner="true"
               :show-category="true"
+              :use-prv-btn="usePrvBtn"
               :is-box-selected-style="isBoxSelectedStyle"
               @previewClick="previewClick"
               @modelNmClick="modelNmClick"
@@ -78,15 +79,15 @@
 import { storeToRefs } from "pinia";
 import Tab from "@extends/tab/Tab.vue";
 import Loading from "@base/loading/Loading.vue";
-import resourceBoxList from "~/components/common/resource-box/resource-box-list.vue";
-import Preview from "~/components/common/preview/preview.vue";
+import resourceBoxList from "@/components/common/resource-box/resource-box-list.vue";
+import Preview from "@/components/common/preview/preview.vue";
 import SearchInput from "@extends/search-input/SearchInput.vue";
 import { useRoute } from "vue-router";
 import { useModal } from "vue-final-modal";
-import profileBox from "~/components/my-page/profile-box.vue";
-import { useMyPageStore } from "~/store/my-page/myPageStore";
+import profileBox from "@/components/my-page/profile-box.vue";
+import { useMyPageStore } from "@/store/my-page/myPageStore";
 import { useUserStore } from "~/store/user/userStore";
-import { useIntersectionObserver } from "~/composables/intersectionObserverHelper";
+import { useIntersectionObserver } from "@/composables/intersectionObserverHelper";
 import { useRouter } from "nuxt/app";
 import pwResetModal from "@/components/my-page/pw-reset-modal.vue";
 
@@ -140,6 +141,9 @@ onMounted(() => {
 
 // 탭 value 초기화
 currentTab.value = "myBookMark";
+
+// 미리보기 show 유무
+const usePrvBtn:Ref = ref(true);
 
 await getTargetUserData(route.query.fqn as string);
 

--- a/project/ovp/frontend/ovp/pages/portal/my-page/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/my-page/index.vue
@@ -45,9 +45,10 @@
               :show-owner="true"
               :show-category="true"
               :use-prv-btn="usePrvBtn"
+              :use-detail-btn="useDetailBtn"
               :is-box-selected-style="isBoxSelectedStyle"
               @previewClick="previewClick"
-              @modelNmClick="modelNmClick"
+              @open-detail-page="openDetailPage"
             />
             <div ref="scrollTrigger" class="w-full h-[1px] mt-px"></div>
             <Loading
@@ -86,7 +87,7 @@ import { useRoute } from "vue-router";
 import { useModal } from "vue-final-modal";
 import profileBox from "@/components/my-page/profile-box.vue";
 import { useMyPageStore } from "@/store/my-page/myPageStore";
-import { useUserStore } from "~/store/user/userStore";
+import { useUserStore } from "@/store/user/userStore";
 import { useIntersectionObserver } from "@/composables/intersectionObserverHelper";
 import { useRouter } from "nuxt/app";
 import pwResetModal from "@/components/my-page/pw-reset-modal.vue";
@@ -142,8 +143,9 @@ onMounted(() => {
 // 탭 value 초기화
 currentTab.value = "myBookMark";
 
-// 미리보기 show 유무
+// 미리보기버튼 / 상세보기버튼 사용유무
 const usePrvBtn:Ref = ref(true);
+const useDetailBtn:Ref = ref(true);
 
 await getTargetUserData(route.query.fqn as string);
 
@@ -186,17 +188,18 @@ const previewClick = async (data: object) => {
   previewIndex = type;
 };
 
-const modelNmClick = (data: object) => {
+function openDetailPage(data: object) {
   const { id, fqn, type } = data as { id: string; fqn: string; type: string };
-  router.push({
-    path: "/portal/search/detail",
-    query: {
-      type: type,
-      id: id,
-      fqn: fqn,
-    },
-  });
-};
+  const queryParams = new URLSearchParams({
+    type,
+    id,
+    fqn,
+  }).toString();
+
+  const fullPath = `/portal/search/detail?${queryParams}`;
+
+  window.open(fullPath, "_blank", "noopener,noreferrer");
+}
 
 const { scrollTrigger, setScrollOptions } = useIntersectionObserver({
   callback: addSearchList,

--- a/project/ovp/frontend/ovp/pages/portal/search/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/search/index.vue
@@ -29,8 +29,8 @@
             :show-category="true"
             :is-box-selected-style="isBoxSelectedStyle"
             :use-prv-btn="true"
+            :use-detail-btn="true"
             @previewClick="previewClick"
-            @modelNmClick="modelNmClick"
           />
           <!-- NOTE "scrollTrigger" -> useIntersectionObserver 가 return 하는 변수병과 동일해야함. -->
           <div ref="scrollTrigger" class="w-full h-[1px] mt-px"></div>
@@ -132,18 +132,6 @@ const previewClick = async (data: object) => {
   isBoxSelectedStyle.value = true;
   currentPreviewId.value = id;
   previewIndex = type;
-};
-
-const modelNmClick = (data: object) => {
-  const { id, fqn, type } = data as { id: string; fqn: string; type: string };
-  router.push({
-    path: "/portal/search/detail",
-    query: {
-      type: type,
-      id: id,
-      fqn: fqn,
-    },
-  });
 };
 
 const tabOptions = ref([

--- a/project/ovp/frontend/ovp/pages/portal/search/index.vue
+++ b/project/ovp/frontend/ovp/pages/portal/search/index.vue
@@ -28,6 +28,7 @@
             :show-owner="true"
             :show-category="true"
             :is-box-selected-style="isBoxSelectedStyle"
+            :use-prv-btn="true"
             @previewClick="previewClick"
             @modelNmClick="modelNmClick"
           />
@@ -74,7 +75,7 @@ import DataFilter from "@/components/search/data-filter.vue";
 
 import TopBar from "./top-bar.vue";
 import { useRouter } from "nuxt/app";
-import { useLayoutHeaderStore } from "~/store/layout/header";
+import { useLayoutHeaderStore } from "@/store/layout/header";
 import { useMenuStore } from "@/store/common/menu";
 
 const router = useRouter();

--- a/project/ovp/frontend/ovp/store/my-page/myPageStore.ts
+++ b/project/ovp/frontend/ovp/store/my-page/myPageStore.ts
@@ -78,6 +78,7 @@ export const useMyPageStore = defineStore("my-page", () => {
 
   const changeTab = async (item: string) => {
     currentTab.value = item;
+    isShowPreview.value = false; // 미리보기 창 닫기
     resetReloadList();
   };
 


### PR DESCRIPTION
## 유형
- Task (기능 변경 외 작업)

## 이슈 링크
- [FAB2023-1344](https://mobigen.atlassian.net/browse/FAB2023-1344)

## 수정 내용
- [FAB2023-1346](https://mobigen.atlassian.net/browse/FAB2023-1346)
- 미리보기 컴포넌트 > 미리보기 버튼 show유무 코드 default값 변경
- 미리보기 show True _ 탐색 목록 / 마이페이지 > 나의 북마크 & 나의 데이터 / 거버넌스 > 카테고리 목록
- 미리보기 show False _ 메인 목록 / 데이터 모델 추가 모달 > 데이터 모델의 추천 데이터 모델


- 상세보기 show True _ 메인 > 목록 / 탐색 목록 / 마이페이지  > 나의 북마크 & 나의 데이터 / 거버넌스 > 카테고리 목록 / portal/search/detail > 연관 데이터모델 시각화 탭(페이지 이동 연결까지는 해둠_ 하드코딩된 값으로 해당 detail페이지로 이동이 안되게 보임) & 추천 데이터 모델 탭 / 데이터모델 생성 > 데이터 모델의 추천 데이터 모델

[FAB2023-1344]: https://mobigen.atlassian.net/browse/FAB2023-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FAB2023-1346]: https://mobigen.atlassian.net/browse/FAB2023-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ