### PR TITLE
[isu-1344] modal에서 등록, 수정, 저장등 버튼에 enter 이벤트 추가

### DIFF
--- a/project/ovp/frontend/common/components/extends/modal/Modal.vue
+++ b/project/ovp/frontend/common/components/extends/modal/Modal.vue
@@ -20,6 +20,7 @@
     @opened="$emit('open')"
     @before-open="$emit('before-open')"
     @before-close="$emit('before-close')"
+    @keydown.enter="$emit('confirm', modalId)"
   >
     <div class="modal-head">
       <div class="modal-head-text">

--- a/project/ovp/frontend/ovp/components/classification/modal/classification-create.vue
+++ b/project/ovp/frontend/ovp/components/classification/modal/classification-create.vue
@@ -6,7 +6,7 @@
     :height="400"
     :top="380"
     :esc-to-close="true"
-    :btn-msg="'저장'"
+    :confirm-btn-msg="'저장'"
     @close="closeModal"
     @cancel="closeModal"
     @confirm="validateForm"

--- a/project/ovp/frontend/ovp/components/classification/modal/tag-create.vue
+++ b/project/ovp/frontend/ovp/components/classification/modal/tag-create.vue
@@ -6,7 +6,7 @@
     :height="400"
     :top="380"
     :esc-to-close="true"
-    :btn-msg="'저장'"
+    :confirm-btn-msg="'저장'"
     @close="closeModal"
     @cancel="closeModal"
     @confirm="validateForm"

--- a/project/ovp/frontend/ovp/components/classification/modal/tag-modify.vue
+++ b/project/ovp/frontend/ovp/components/classification/modal/tag-modify.vue
@@ -6,7 +6,7 @@
     :height="500"
     :width="480"
     :esc-to-close="true"
-    :btn-msg="'저장'"
+    :confirm-btn-msg="'저장'"
     @close="closeModal"
     @cancel="closeModal"
     @confirm="validateForm"
@@ -145,6 +145,8 @@ function validateForm(): void {
   }
   isShowDescNoti.value = false;
 
+
+// TODO : 수정하지 않고 저장 버튼 클릭시, saveTag로 undefined로 넘어오는 문제 해결
   // store에 있는 edit 호출하기
   saveTag(tagFormState.value.name, tagFormState.value.description).then(
     (response: any) => {

--- a/project/ovp/frontend/ovp/components/classification/modal/tag-modify.vue
+++ b/project/ovp/frontend/ovp/components/classification/modal/tag-modify.vue
@@ -145,8 +145,6 @@ function validateForm(): void {
   }
   isShowDescNoti.value = false;
 
-
-// TODO : 수정하지 않고 저장 버튼 클릭시, saveTag로 undefined로 넘어오는 문제 해결
   // store에 있는 edit 호출하기
   saveTag(tagFormState.value.name, tagFormState.value.description).then(
     (response: any) => {
@@ -182,6 +180,9 @@ function saveTag(name: any, description: any) {
     };
     return editClassificationTag(editData, props.formInfo.id);
   }
+
+  // 변경 사항이 없을 경우에도 Promise 반환
+  return Promise.resolve({ result: 0 }); // result 0 → 변경 사항 없음
 }
 
 function closeModal(): void {

--- a/project/ovp/frontend/ovp/components/datamodel-creation/modal/save.vue
+++ b/project/ovp/frontend/ovp/components/datamodel-creation/modal/save.vue
@@ -15,6 +15,7 @@
     @before-open="onOpenModal"
     @click-outside="onCancelModal"
     @cancel="onCancelModal"
+    @confirm="onSaveModal"
   >
     <template v-slot:body>
       <div class="form form-lg">

--- a/project/ovp/frontend/ovp/components/govern/glossary/modal/modal-glossary-dictionary.vue
+++ b/project/ovp/frontend/ovp/components/govern/glossary/modal/modal-glossary-dictionary.vue
@@ -6,7 +6,7 @@
     :height="500"
     :width="480"
     :esc-to-close="true"
-    :btn-msg="'저장'"
+    :confirm-btn-msg="'저장'"
     @close="closeModal"
     @cancel="closeModal"
     @confirm="validateForm"

--- a/project/ovp/frontend/ovp/components/govern/glossary/modal/modal-glossary.vue
+++ b/project/ovp/frontend/ovp/components/govern/glossary/modal/modal-glossary.vue
@@ -6,7 +6,7 @@
     :esc-to-close="true"
     :width="480"
     :height="600"
-    :btn-msg="'저장'"
+    :confirm-btn-msg="'저장'"
     @close="closeModal"
     @cancel="closeModal"
     @confirm="validateForm"

--- a/project/ovp/frontend/ovp/components/manage/service/modal/collection/modal-collection.vue
+++ b/project/ovp/frontend/ovp/components/manage/service/modal/collection/modal-collection.vue
@@ -15,6 +15,7 @@
     @before-open="onBeforeOpen"
     @closed="onClosed(false)"
     @cancel="onClosed(false)"
+    @confirm="gotoNext"
   >
     <template v-slot:body>
       <Step

--- a/project/ovp/frontend/ovp/components/manage/service/modal/modal-service/modal-service.vue
+++ b/project/ovp/frontend/ovp/components/manage/service/modal/modal-service/modal-service.vue
@@ -15,6 +15,7 @@
     @before-open="beforeOpen"
     @closed="onCancel"
     @cancel="onCancel"
+    @confirm="gotoNext"
   >
     <template #body>
       <Step


### PR DESCRIPTION
## 유형
- Feature (기능 추가 or 개선)
- Issue (버그 수정 등)

## 이슈 링크
- [FAB2023-1344](https://mobigen.atlassian.net/browse/FAB2023-1344)

## 수정 내용
- [FAB2023-1386](https://mobigen.atlassian.net/browse/FAB2023-1386)
- modal에서 등록, 수정, 저장등 버튼에 enter 이벤트 추가 
- 태그 수정 모달내에 변경 사항이 없을 경우에도 Promise 반환되도록 수정 

[FAB2023-1344]: https://mobigen.atlassian.net/browse/FAB2023-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FAB2023-1386]: https://mobigen.atlassian.net/browse/FAB2023-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ