### PR TITLE
[FAB2023-1521] 데이터모델 생성 / 데이터 모델 목록이 없을 때 필터 초기화

### DIFF
--- a/project/ovp/frontend/common/components/extends/menu-seach/MenuSearchComposition.ts
+++ b/project/ovp/frontend/common/components/extends/menu-seach/MenuSearchComposition.ts
@@ -44,7 +44,10 @@ export function MenuSearchComposition(
     if (_.isEmpty(props.data)) {
       return;
     }
-    const result = props.data.map((item) => {
+    // 'buckets' 키가 존재하면 해당 배열을 사용
+    const dataList = props.data.hasOwnProperty('buckets') ? props.data.buckets : props.data;
+
+    const result = dataList.map((item) => {
       const isChecked = isCheckedData(item);
       return {
         id: uuid.v4(),

--- a/project/ovp/frontend/ovp/components/datamodel-creation/list/base/DataModelListComposition.ts
+++ b/project/ovp/frontend/ovp/components/datamodel-creation/list/base/DataModelListComposition.ts
@@ -210,6 +210,11 @@ export function DataModelListComposition(
     });
     const selectedList = $_reject(listData.value, { id: value });
     emitDeleteItem(selectedList);
+
+    // 필터 초기화 추가
+    for (const key in selectedFilter) {
+      selectedFilter[key] = [];
+    }
   };
 
   /**

--- a/project/ovp/frontend/ovp/components/govern/common/modal/add-data-model.vue
+++ b/project/ovp/frontend/ovp/components/govern/common/modal/add-data-model.vue
@@ -197,7 +197,7 @@ const emit = defineEmits<{
 }>();
 
 const beforeOpen = async () => {
-  await getFilters();
+  await getFilters(currentTab.value);
 };
 
 const inputSearchKeyword = (searchKeyword?: string) => {
@@ -209,9 +209,10 @@ const inputSearchKeyword = (searchKeyword?: string) => {
   getDataModelList();
 };
 
-const changeTab = (item: string) => {
+const changeTab = async (item: string) => {
   currentTab.value = item;
   getDataModelList();
+  await getFilters(item);
 };
 
 const selectedDataModelCount = computed(() => {

--- a/project/ovp/frontend/ovp/components/search/detail-tab/lineage.vue
+++ b/project/ovp/frontend/ovp/components/search/detail-tab/lineage.vue
@@ -74,7 +74,7 @@ let previewModelType = "table";
 onBeforeMount(async () => {
   isShowPreview.value = false;
   setEmptyFilter();
-  await getFilters();
+  await getFilters(dataModelType.value);
   await getLineageData(dataModelType.value, getDataModelFqn());
 });
 

--- a/project/ovp/frontend/ovp/store/datamodel-creation/search.ts
+++ b/project/ovp/frontend/ovp/store/datamodel-creation/search.ts
@@ -335,6 +335,10 @@ export const useDataModelSearchStore = defineStore("dataModelSearch", () => {
     setSearchKeyword("");
     setSearchMyKeyword("");
 
+    // 탭 변경 시 하위 버튼 초기화
+    currTypeMyTab.value = $constants.DATAMODEL_CREATION.ADD.MY_DATA_TAB[0].value;
+    currTypeTab.value = $constants.COMMON.DATA_TYPE[0].value;
+
     nextTick(() => {
       // 두 tab 다 infinite scroll 이 설정 되어 있기 때문에 tab 전환시 설정 flag 를 초기화해준다.
       // dom 에 infinite scroll 이 적용될 tag가 생성 된 후에 infinite scroll 을 설정해줘야 동작하기 때문에 nextTick 에서 설정함.
@@ -368,8 +372,6 @@ export const useDataModelSearchStore = defineStore("dataModelSearch", () => {
   const cancelAllSelection = () => {
     // 탭 초기화
     currDetailTab.value = DEFAULT_DETAIL_TAB;
-    // dataModelType 탭 초기화
-    currTypeTab.value = $constants.COMMON.DATA_TYPE[0].value;
 
     nSelectedListData.value = updateSelection(nSelectedListData.value, "");
     searchResult.value = updateSelection(searchResult.value, "");

--- a/project/ovp/frontend/ovp/store/datamodel-creation/search.ts
+++ b/project/ovp/frontend/ovp/store/datamodel-creation/search.ts
@@ -305,11 +305,12 @@ export const useDataModelSearchStore = defineStore("dataModelSearch", () => {
    * 중분류 Tab 변경
    * @param item
    */
-  const changeTypeTab = (item: string) => {
+  const changeTypeTab = async (item: string) => {
     cancelAllSelection();
     setSelectedItem({});
     currTypeTab.value = item;
     resetReloadList(nSelectedListData.value);
+    await getFilters(item);
   };
 
   /**
@@ -367,6 +368,8 @@ export const useDataModelSearchStore = defineStore("dataModelSearch", () => {
   const cancelAllSelection = () => {
     // 탭 초기화
     currDetailTab.value = DEFAULT_DETAIL_TAB;
+    // dataModelType 탭 초기화
+    currTypeTab.value = $constants.COMMON.DATA_TYPE[0].value;
 
     nSelectedListData.value = updateSelection(nSelectedListData.value, "");
     searchResult.value = updateSelection(searchResult.value, "");
@@ -546,11 +549,13 @@ export const useDataModelSearchStore = defineStore("dataModelSearch", () => {
   /**
    * API- 필터 조회
    */
-  const getFilters = async () => {
-    const { data } = await $api(`/api/search/filters`, { showLoader: false });
+  const getFilters = async (dataModelType: string = "table") => {
+    const { data } = await $api(`/api/search/filters?dataModelType=${dataModelType}`, { showLoader: false });
 
     // 기본값 기준 사용할 필터 key 를 정리
     const defaultFilters = createDefaultFilters();
+    // 필터 초기화
+    selectedFilters.value = [];
     const useFilters = Object.keys(defaultFilters);
 
     useFilters.forEach((key: string) => {

--- a/project/ovp/frontend/ovp/store/datamodel-creation/search.ts
+++ b/project/ovp/frontend/ovp/store/datamodel-creation/search.ts
@@ -309,6 +309,7 @@ export const useDataModelSearchStore = defineStore("dataModelSearch", () => {
     cancelAllSelection();
     setSelectedItem({});
     currTypeTab.value = item;
+    searchResult.value = [];
     resetReloadList(nSelectedListData.value);
     await getFilters(item);
   };

--- a/project/ovp/frontend/ovp/store/governance/common/modal/data-model/index.ts
+++ b/project/ovp/frontend/ovp/store/governance/common/modal/data-model/index.ts
@@ -95,8 +95,11 @@ export const useDataModelTag = defineStore("DataModelTag", () => {
   /**
    * 필터 조회
    */
-  const getFilters = async () => {
-    const { data } = await $api(`/api/search/filters`);
+  const getFilters = async (dataModelType: string = "table") => {
+    // TODO : 필터 초기화함수로, 추후 불필요시 제거.
+    setEmptyFilter();
+
+    const { data } = await $api(`/api/search/filters?dataModelType=${dataModelType}`);
 
     const defaultFilters = createDefaultFilters();
     const useFilters = Object.keys(defaultFilters);

--- a/project/ovp/frontend/ovp/store/search/common.ts
+++ b/project/ovp/frontend/ovp/store/search/common.ts
@@ -213,6 +213,10 @@ export const useSearchCommonStore = defineStore(
       setSize(stackedFromCount.value);
 
       const { data, totalCount } = await getSearchListAPI();
+
+      if (data[currentTab.value].size === 0)
+          currentTab.value = "storage";
+
       searchResult.value = data[currentTab.value];
       searchResultLength.value = totalCount;
       isSearchResultNoData.value = searchResult.value.length === 0;
@@ -223,9 +227,9 @@ export const useSearchCommonStore = defineStore(
       selectedFilters.value = {};
     };
 
-    const getFilters = async () => {
-      filters.value = (await getUseFilters(createDefaultFilters())) as Filters;
+    const getFilters = async (dataModelType: string = 'table') => {
 
+     filters.value = (await getUseFilters(createDefaultFilters(), dataModelType)) as Filters;
       // 미분류 카테고리 ID 저장
       UNDEFINED_TAG_ID =
         filters.value[FILTER_KEYS.CATEGORY].data.children[0].id;
@@ -233,8 +237,9 @@ export const useSearchCommonStore = defineStore(
 
     const getUseFilters = async (
       defaultFilters: Filters | Partial<Filters>,
+      dataModelType: string
     ) => {
-      const { data } = await $api(`/api/search/filters`);
+        const { data } = await $api(`/api/search/filters?dataModelType=${dataModelType}`);
 
       // 기본값 기준 사용할 필터 key 를 정리
       const useFilters = Object.keys(defaultFilters);
@@ -247,11 +252,11 @@ export const useSearchCommonStore = defineStore(
       return filtersData;
     };
 
-    const getFilter = async (filterKey: string) => {
-      // TODO : 서버 연동 후 json 가라 데이터 삭제, 실 데이터로 변경 처리 필요.
-      const data = await $api(`/api/search/filter?field=${filterKey}`);
-      (filters.value as Filters)[filterKey].data = data.data[filterKey];
-    };
+    // const getFilter = async (filterKey: string) => {
+    //   // TODO : 서버 연동 후 json 가라 데이터 삭제, 실 데이터로 변경 처리 필요.
+    //   const data = await $api(`/api/search/filter?field=${filterKey}`);
+    //   (filters.value as Filters)[filterKey].data = data.data[filterKey];
+    // };
 
     const getPreviewData = async (fqn: string) => {
       const data = await getPreviewAPI(fqn);
@@ -340,7 +345,8 @@ export const useSearchCommonStore = defineStore(
       showDropDown.value = false;
       showGraphModelListMenu.value = false;
       currentTab.value = item;
-
+      // 탭[테이블 / 스토리지 / 융합모델] 종류에 따른 필터항목 조회
+      await getFilters(currentTab.value);
       if (loadList) {
         resetReloadList();
         viewType.value === "graphView" ? await getGraphData() : null;

--- a/project/ovp/frontend/ovp/store/search/common.ts
+++ b/project/ovp/frontend/ovp/store/search/common.ts
@@ -302,8 +302,12 @@ export const useSearchCommonStore = defineStore(
           key === "category"
             ? getCtgIds(undefinedTagId, selectedFilters)
             : (selectedFilters as SelectedFilters)[key];
-        const keyValue = key === "category" ? "tags.tagFQN" : key;
+        let keyValue = key === "category" ? "tags.tagFQN" : key;
 
+        // 'storage' 탭일 경우 키 값을 변경
+        if (currentTab.value === "storage" && keyValue === "columns.name.keyword") {
+          keyValue = "dataModel.columns.name.keyword";
+        }
         queryFilter.query.bool.must.push(
           setQueryFilterByDepth(keyValue, value),
         );
@@ -553,7 +557,6 @@ export const useSearchCommonStore = defineStore(
       lowestCategoryIdList,
       addSearchList,
       getSearchList,
-      getFilter,
       getFilters,
       getUseFilters,
       createDefaultPreview,

--- a/project/ovp/frontend/ovp/store/search/detail/lineage/index.ts
+++ b/project/ovp/frontend/ovp/store/search/detail/lineage/index.ts
@@ -3,6 +3,7 @@ import { FILTER_KEYS, useSearchCommonStore } from "@/store/search/common";
 import { ref } from "vue";
 import _ from "lodash";
 import type { PreviewData } from "@/type/common";
+import {storeToRefs} from "pinia";
 
 export interface lineageData {
   nodes: any[];
@@ -19,6 +20,9 @@ export const useLineageStore = defineStore("lineage", () => {
     getPreviewAPI,
     getContainerPreviewAPI,
   } = searchCommonStore;
+  const {
+    currentTab
+  } = storeToRefs(searchCommonStore);
 
   // filters 초기값 부여 (text 처리)
   const createDefaultFilters = (): Partial<Filters> => {
@@ -43,6 +47,7 @@ export const useLineageStore = defineStore("lineage", () => {
   const getFilters = async () => {
     filters.value = (await getUseFilters(
       createDefaultFilters(),
+      currentTab,
     )) as Partial<Filters>;
 
     // 미분류 카테고리 ID 저장

--- a/project/ovp/frontend/ovp/store/search/detail/lineage/index.ts
+++ b/project/ovp/frontend/ovp/store/search/detail/lineage/index.ts
@@ -3,7 +3,6 @@ import { FILTER_KEYS, useSearchCommonStore } from "@/store/search/common";
 import { ref } from "vue";
 import _ from "lodash";
 import type { PreviewData } from "@/type/common";
-import {storeToRefs} from "pinia";
 
 export interface lineageData {
   nodes: any[];
@@ -20,9 +19,6 @@ export const useLineageStore = defineStore("lineage", () => {
     getPreviewAPI,
     getContainerPreviewAPI,
   } = searchCommonStore;
-  const {
-    currentTab
-  } = storeToRefs(searchCommonStore);
 
   // filters 초기값 부여 (text 처리)
   const createDefaultFilters = (): Partial<Filters> => {
@@ -44,11 +40,11 @@ export const useLineageStore = defineStore("lineage", () => {
   const lineageFilterRef = ref(null);
   const previewData: Ref<PreviewData> = ref(createDefaultPreview());
 
-  const getFilters = async () => {
+  const getFilters = async (dataModelType: string) => {
     filters.value = (await getUseFilters(
-      createDefaultFilters(),
-      currentTab,
-    )) as Partial<Filters>;
+      createDefaultFilters() as Partial<Filters>,
+      dataModelType,
+    ));
 
     // 미분류 카테고리 ID 저장
     const categoryData = filters.value[FILTER_KEYS.CATEGORY]?.data;

--- a/project/ovp/server/src/main/java/com/mobigen/ovp/search/SearchController.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/search/SearchController.java
@@ -40,8 +40,8 @@ public class SearchController {
      */
     @ResponseJsonResult(errorMessage = "filter 목록 조회 오류")
     @GetMapping("/filters")
-    public Object getFilters() throws Exception {
-        Map<String, Object> responseMap = searchService.getFilters();
+    public Object getFilters(@RequestParam ("dataModelType") String dataModelType) throws Exception {
+        Map<String, Object> responseMap = searchService.getFilters(dataModelType);
         responseMap.put("category", categoryService.getCategories());
         return responseMap;
     }

--- a/project/ovp/server/src/main/java/com/mobigen/ovp/search/SearchService.java
+++ b/project/ovp/server/src/main/java/com/mobigen/ovp/search/SearchService.java
@@ -13,10 +13,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.springframework.cloud.openfeign.Targeter;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +35,7 @@ public class SearchService {
     private final ModelConvertUtil modelConvertUtil;
     private final CategoryRepository categoryRepository;
     private final CategoryConvertUtil categoryConvertUtil;
+    private final Targeter targeter;
 
     private Map<String, Object> convertAggregations(Map<String, Object> response) {
         Map<String, Object> aggregations = (Map<String, Object>) response.get("aggregations");
@@ -65,7 +68,10 @@ public class SearchService {
                             resultMap.put(newKey, filteredBuckets);
                         }
                     } else {
-                        resultMap.put(newKey, buckets);
+                        if (newKey.equals("dataModel.columns.name.keyword"))
+                            resultMap.put("columns.name.keyword", value);
+                        else
+                            resultMap.put(newKey, buckets);
                     }
                 }
             }
@@ -74,28 +80,38 @@ public class SearchService {
     }
 
     public Map<String, Object> getFilter(MultiValueMap<String, String> params) {
-        params.set("q", "{\"query\":{\"bool\":{\"must\":[{\"match\":{\"deleted\":false}},{\"terms\":{\"_index\":[\"" + Constants.CONTAINER_INDEX + "\",\"" + Constants.TABLE_INDEX + "\"]}}]}}}");
+        params.set("q", "{\"query\":{\"bool\":{\"must\":[]}}}");
         params.set("value", ".*.*");
-        params.set("index", "all");
         return convertAggregations(searchClient.getFilter(params));
     }
 
-    public Map<String, Object> getFilters() throws Exception {
-        List<String> tagArrays = Arrays.asList(
+    public Map<String, Object> getFilters(String dataModelType) throws Exception {
+        List<String> tagArrays = new ArrayList<>(Arrays.asList(
                 "owner.displayName.keyword",
                 "tags.tagFQN",
                 "service.displayName.keyword",
-                "serviceType",
-                "database.displayName.keyword",
-                "databaseSchema.displayName.keyword",
-                "columns.name.keyword"
-        );
-
+                "serviceType"
+        ));
+        // dataModelType에 따른 tagArrays 추가
+        if ("storage".equalsIgnoreCase(dataModelType)) {
+            tagArrays.add("dataModel.columns.name.keyword");
+        } else {
+            tagArrays.addAll(Arrays.asList(
+                    "database.displayName.keyword",
+                    "databaseSchema.displayName.keyword",
+                    "columns.name.keyword"
+            ));
+        }
         Map<String, Object> responseMap = new HashMap<>();
 
         for (String tag : tagArrays) {
             MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
             params.set("field", tag);
+            if(dataModelType.equalsIgnoreCase("table") || dataModelType.equalsIgnoreCase("model")) {
+                params.set("index", "table_search_index");
+            } else {
+                params.set("index", "container_search_index");
+            }
             Map<String, Object> filterResult = getFilter(params);
             responseMap.putAll(filterResult);
         }


### PR DESCRIPTION
## 유형
- Issue (버그 수정 등)

## 이슈 링크
- [FAB2023-1344](https://mobigen.atlassian.net/browse/FAB2023-1344)

## 수정 내용
- [FAB2023-1521](https://mobigen.atlassian.net/browse/FAB2023-1521)
- 데이터 모델을 추가 후 모델 목록을 모두 삭제하면 필터값이 남아 있는 문제 수정
- 데이터 모델 추가 모달에서 테이블, 스토리지, 융합모델 탭을 클릭시 기존 데이너가 남아 있는 문제 수정
- 생성 모달에서 스토리지 탭 이동수 모달을 닫고 다시 모달을 오픈하면 스토리지 탭이 그대로 선택되어 있는 문제 (탭 선택 초기화)

[FAB2023-1344]: https://mobigen.atlassian.net/browse/FAB2023-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FAB2023-1521]: https://mobigen.atlassian.net/browse/FAB2023-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ